### PR TITLE
Fix host binding for express

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -86,6 +86,6 @@ app.post('/upload', authMiddleware, upload.single('file'), (req, res) => {
     res.json({ success: true, data: { filename: req.file.filename, url } });
 });
 
-app.listen(PORT, () => {
+app.listen(PORT, '0.0.0.0', () => {
     console.log(`Server listening on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- bind Express server to `0.0.0.0` so Fly.io can reach it

## Testing
- `npm install`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c679d8628832383fc6525a961f266