### PR TITLE
Configure Fly with healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ Der Server liest folgende Umgebungsvariablen:
 ## Deployment auf Fly.io
 
 1. Installiere `flyctl` und melde dich an.
-2. Erstelle (falls noch nicht geschehen) eine App und ein Volume, z. B. mit
+2. Erstelle (falls noch nicht geschehen) eine App, z. B. mit
    ```
-   flyctl apps create mailmarketing-app --machines
-   flyctl volumes create data --size 1 --region ams
+   flyctl apps create mailmarketing --machines
    ```
-3. Prüfe die Datei `fly.toml`. Darin sind Port und Umgebungsvariablen für das
-   Backend definiert. Bei Bedarf passe den `AUTH_TOKEN` an.
+3. Prüfe die Datei `fly.toml`. Darin ist die HTTP‑Service-Konfiguration samt
+   Healthcheck hinterlegt. Weitere Umgebungsvariablen lassen sich bei Bedarf
+   über `fly secrets` setzen.
 4. Starte das Deployment mit
    ```
    flyctl deploy
    ```
-5. Die URL der App (z.B. `https://mailmarketing-app.fly.dev`) kann anschließend
+5. Die URL der App (z.B. `https://mailmarketing.fly.dev`) kann anschließend
    im Frontend via `ServerConfig.set({ baseUrl: '<URL>' })` gesetzt werden.
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,24 +1,28 @@
-app = "mailmarketing-app"
-primary_region = "ams"
+app = "mailmarketing"
+primary_region = "iad"
 
 [build]
   dockerfile = "Dockerfile"
 
-[env]
-  PORT = "3000"
-  AUTH_TOKEN = "changeme"
-  DB_PATH = "/data/db.sqlite"
-  UPLOAD_DIR = "/data/uploads"
+[http_service]
+  internal_port       = 8080
+  auto_start_machines = true
+  auto_stop_machines  = true
+  min_machines_running = 0
+  processes = ["app"]
 
-[[mounts]]
-  source = "data"
-  destination = "/data"
-
-[[services]]
-  internal_port = 3000
-  protocol = "tcp"
-
-  [[services.ports]]
+  force_https = true
+  [[http_service.ports]]
+    handlers = ["http"]
     port = 80
-  [[services.ports]]
+
+  [[http_service.ports]]
+    handlers = ["tls", "http"]
     port = 443
+
+  [[http_service.checks]]
+    method   = "get"
+    interval = "30s"
+    timeout  = "5s"
+    path     = "/recipients"
+    protocol = "http"


### PR DESCRIPTION
## Summary
- simplify deployment instructions in README
- replace Fly.io config with Machines v2 setup and healthcheck

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c6ec9a794832393c34296868c38af