### PR TITLE
Merge Fly healthcheck config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:20-alpine
 WORKDIR /app
+RUN apk add --no-cache python3 make g++
 COPY backend/package*.json ./backend/
 RUN cd backend && npm install --production
 COPY . .

--- a/README.md
+++ b/README.md
@@ -31,5 +31,18 @@ Der Server liest folgende Umgebungsvariablen:
 
 ## Deployment auf Fly.io
 
-
+1. Installiere `flyctl` und melde dich an.
+2. Erstelle (falls noch nicht geschehen) eine App, z. B. mit
+   ```
+   flyctl apps create mailmarketing --machines
+   ```
+3. Prüfe die Datei `fly.toml`. Darin ist die HTTP‑Service-Konfiguration samt
+   Healthcheck hinterlegt. Weitere Umgebungsvariablen lassen sich bei Bedarf
+   über `fly secrets` setzen.
+4. Starte das Deployment mit
+   ```
+   flyctl deploy
+   ```
+5. Die URL der App (z.B. `https://mailmarketing.fly.dev`) kann anschließend
+   im Frontend via `ServerConfig.set({ baseUrl: '<URL>' })` gesetzt werden.
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,29 @@
-app = "mailmarketing-app"
+app = "mailmarketing"
+primary_region = "iad"
 
 
 [build]
   dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port       = 8080
+  auto_start_machines = true
+  auto_stop_machines  = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  force_https = true
+  [[http_service.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[http_service.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[http_service.checks]]
+    method   = "get"
+    interval = "30s"
+    timeout  = "5s"
+    path     = "/recipients"
+    protocol = "http"


### PR DESCRIPTION
## Summary
- merge branch `codex/empfänger-persistent-speichern-mit-datenbank`
- incorporate Fly.io healthcheck config in README and fly.toml
- install build tools in Dockerfile

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c826b6fe88323b7f3fbb58435417a