### PR TITLE
Fix PORT env usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ COPY backend/package*.json ./backend/
 RUN cd backend && npm install --production
 COPY . .
 WORKDIR /app/backend
-ENV PORT=3000
+ENV PORT=8080
 CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ein einfacher Express-Server speichert Empfänger und hochgeladene Dateien in ei
    ```
 
 Der Server liest folgende Umgebungsvariablen:
-- `PORT` – Port, auf dem der Server lauscht (Standard 3000)
+ - `PORT` – Port, auf dem der Server lauscht (wird durch die Umgebung vorgegeben, z. B. 8080 bei Fly.io)
 - `DB_PATH` – Pfad zur SQLite-Datei (Standard `backend/db.sqlite`)
 - `AUTH_TOKEN` – Bearer Token für geschützte Endpunkte
 - `UPLOAD_DIR` – Ablageort für hochgeladene Dateien (Standard `backend/uploads`)

--- a/backend/index.js
+++ b/backend/index.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fs = require('fs');
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT;
 const DB_PATH = process.env.DB_PATH || path.join(__dirname, 'db.sqlite');
 const AUTH_TOKEN = process.env.AUTH_TOKEN || 'secret-token';
 const UPLOAD_DIR = process.env.UPLOAD_DIR || path.join(__dirname, 'uploads');


### PR DESCRIPTION
## Summary
- rely solely on PORT from env
- update Docker default port to 8080
- clarify README about required PORT

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d2da6ae508323a8f4b7f22b302ab3