### PR TITLE
Replace real EmailJS public key placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 
                     <div class="form-group">
                         <label for="wizard-userId">Public Key:</label>
-                        <input type="text" id="wizard-userId" placeholder="E7m0JpVn9GC6WNcvF">
+                        <input type="text" id="wizard-userId" placeholder="T5m1UpGrxxxxxxxxx">
                         <small>Unter "Account" > "General" in deinem Dashboard</small>
                     </div>
                 </div>
@@ -648,7 +648,7 @@
                 
                 <div class="form-group">
                     <label for="userId">Public Key:</label>
-                    <input type="text" id="userId" placeholder="E7m0JpVn9GC6WNcvF">
+                    <input type="text" id="userId" placeholder="T5m1UpGrxxxxxxxxx">
                 </div>
                 
                 <div class="form-group">


### PR DESCRIPTION
## Summary
- replace the EmailJS public key example in the setup wizard with a more realistic placeholder `T5m1UpGrxxxxxxxxx`

## Testing
- `npm test` *(fails: no package.json)*
- `npm install` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d319024ec832381c973257f3d0038