### PR TITLE
Improve registration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Der Server liest folgende Umgebungsvariablen:
 - `DB_PATH` – Pfad zur SQLite-Datei (Standard `backend/db.sqlite`)
 - `AUTH_TOKEN` – Bearer Token für geschützte Endpunkte
 - `UPLOAD_DIR` – Ablageort für hochgeladene Dateien (Standard `backend/uploads`)
+- `JWT_SECRET` – Geheimschlüssel für die Signierung der JWTs
 
 ### API-Beispiele
 
@@ -28,6 +29,12 @@ Der Server liest folgende Umgebungsvariablen:
 - `POST /recipients` – Empfänger anlegen (Header `Authorization: Bearer <TOKEN>`)
 - `DELETE /recipients/:id` – Empfänger löschen (Header `Authorization: Bearer <TOKEN>`)
 - `POST /upload` – Datei hochladen (Header `Authorization: Bearer <TOKEN>`, Feldname `file`)
+- `POST /register` – neuen Benutzer anlegen
+- `POST /login` – Login, gibt ein JWT zurück
+
+Im Frontend findest du die Seiten `login.html` und `register.html`. Nach einem
+erfolgreichen Login speichert das Skript `js/auth.js` das erhaltene JWT in
+`ServerConfig`, damit weitere API-Aufrufe authentifiziert erfolgen.
 
 ## Deployment auf Fly.io
 
@@ -43,6 +50,8 @@ Der Server liest folgende Umgebungsvariablen:
    ```
    flyctl deploy
    ```
-5. Die URL der App (z.B. `https://mailmarketing.fly.dev`) kann anschließend
-   im Frontend via `ServerConfig.set({ baseUrl: '<URL>' })` gesetzt werden.
+5. Standardmäßig nutzen die Frontend-Skripte die aktuelle Herkunft (Origin)
+   des Browsers als Basis-URL. Falls du den Server von einer anderen Domain
+   aufrufst, kannst du die URL manuell mit
+   `ServerConfig.set({ baseUrl: '<URL>' })` anpassen.
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^3.0.2",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
         "sqlite3": "^5.1.7"
       }
@@ -182,6 +184,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -256,6 +267,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -553,6 +570,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1139,6 +1165,91 @@
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,8 +11,10 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "bcryptjs": "^3.0.2",
     "express": "^5.1.0",
-    "sqlite3": "^5.1.7",
-    "multer": "^1.4.5-lts.1"
+    "jsonwebtoken": "^9.0.2",
+    "multer": "^1.4.5-lts.1",
+    "sqlite3": "^5.1.7"
   }
 }

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,61 @@
+window.Auth = (function() {
+    async function login(email, password) {
+        try {
+            const resp = await fetch(ServerConfig.get().baseUrl + '/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email, password })
+            });
+            if (!resp.ok) throw new Error('Login failed');
+            const data = await resp.json();
+            if (data.token) {
+                ServerConfig.set({ authToken: data.token });
+                return true;
+            }
+        } catch (err) {
+            console.error('Login error:', err);
+        }
+        return false;
+    }
+
+    async function register(email, password) {
+        try {
+            const resp = await fetch(ServerConfig.get().baseUrl + '/register', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email, password })
+            });
+            if (!resp.ok) throw new Error('Register failed');
+            return true;
+        } catch (err) {
+            console.error('Register error:', err);
+        }
+        return false;
+    }
+
+    return { login, register };
+})();
+
+document.getElementById('loginForm')?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('loginEmail').value;
+    const password = document.getElementById('loginPassword').value;
+    const ok = await Auth.login(email, password);
+    if (ok) {
+        window.location.href = 'index.html';
+    } else {
+        document.getElementById('loginError').textContent = 'Login fehlgeschlagen';
+    }
+});
+
+document.getElementById('registerForm')?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('regEmail').value;
+    const password = document.getElementById('regPassword').value;
+    const ok = await Auth.register(email, password);
+    if (ok) {
+        window.location.href = 'login.html';
+    } else {
+        document.getElementById('registerError').textContent = 'Registrierung fehlgeschlagen';
+    }
+});

--- a/js/server-config.js
+++ b/js/server-config.js
@@ -1,6 +1,9 @@
 window.ServerConfig = (function() {
     const DEFAULT_CONFIG = {
-        baseUrl: 'http://localhost:3000',
+        // Falls im Frontend keine URL gesetzt wird, nutzen wir die aktuelle
+        // Herkunft des Browsers. Das funktioniert direkt nach dem Deployment
+        // auf Fly.io ohne weitere Anpassungen.
+        baseUrl: '',
         authToken: 'secret-token'
     };
 

--- a/login.html
+++ b/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="login-container">
+        <h1>Login</h1>
+        <form id="loginForm">
+            <input type="email" id="loginEmail" placeholder="E-Mail" autocomplete="username" required>
+            <input type="password" id="loginPassword" placeholder="Passwort" autocomplete="current-password" required>
+            <button type="submit">Login</button>
+        </form>
+        <div id="loginError" class="error"></div>
+    </div>
+    <script src="js/server-config.js"></script>
+    <script src="js/auth.js"></script>
+</body>
+</html>

--- a/register.html
+++ b/register.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Registrierung</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="login-container">
+        <h1>Registrieren</h1>
+        <form id="registerForm">
+            <input type="email" id="regEmail" placeholder="E-Mail" autocomplete="email" required>
+            <input type="password" id="regPassword" placeholder="Passwort" autocomplete="new-password" required>
+            <button type="submit">Registrieren</button>
+        </form>
+        <div id="registerError" class="error"></div>
+    </div>
+    <script src="js/server-config.js"></script>
+    <script src="js/auth.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- hook up registration through `js/auth.js`
- call login/register pages for JWT-based auth
- document login and registration in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `PORT=3000 node backend/index.js` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_684d30eef9d48323b59383480c02734b