### PR TITLE
Fix register error by using current origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Der Server liest folgende Umgebungsvariablen:
    ```
    flyctl deploy
    ```
-5. Die URL der App (z.B. `https://mailmarketing.fly.dev`) kann anschließend
-   im Frontend via `ServerConfig.set({ baseUrl: '<URL>' })` gesetzt werden.
+5. Standardmäßig nutzt das Frontend `window.location.origin` als Basis-URL.
+   Bei Bedarf kann die Adresse (z.B. `https://mailmarketing.fly.dev`)
+   manuell via `ServerConfig.set({ baseUrl: '<URL>' })` überschrieben werden.
 

--- a/js/server-config.js
+++ b/js/server-config.js
@@ -1,6 +1,6 @@
 window.ServerConfig = (function() {
     const DEFAULT_CONFIG = {
-        baseUrl: 'http://localhost:3000',
+        baseUrl: window.location.origin,
         authToken: 'secret-token'
     };
 


### PR DESCRIPTION
## Summary
- default the API base URL to `window.location.origin`
- clarify README on how the base URL is chosen and how to override it

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d6e79cb8c832394ddf92b2096dbea