### PR TITLE
Improve user workflow and admin features

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -15,6 +15,17 @@
             </thead>
             <tbody></tbody>
         </table>
+        <h2>Neuen Benutzer anlegen</h2>
+        <form id="createUserForm">
+            <input type="email" id="newUserEmail" placeholder="E-Mail" required>
+            <input type="password" id="newUserPassword" placeholder="Passwort" required>
+            <select id="newUserRole">
+                <option value="user">User</option>
+                <option value="admin">Admin</option>
+            </select>
+            <button type="submit">Anlegen</button>
+        </form>
+        <div id="userMessage" class="success"></div>
         <div id="userError" class="error"></div>
     </div>
     <script src="js/server-config.js"></script>

--- a/js/admin.js
+++ b/js/admin.js
@@ -33,19 +33,54 @@ window.Admin = (function() {
                 headers: { 'Authorization': `Bearer ${ServerConfig.get().authToken}` }
             });
             if (resp.ok) {
+                document.getElementById('userMessage').textContent = 'Benutzer gelöscht';
                 loadUsers();
             } else {
                 throw new Error('Failed');
             }
         } catch (err) {
-            alert('Löschen fehlgeschlagen');
+            document.getElementById('userError').textContent = 'Löschen fehlgeschlagen';
             console.error('deleteUser', err);
         }
     }
 
-    return { loadUsers };
+    async function createUser(email, password, role) {
+        const msgEl = document.getElementById('userMessage');
+        const errEl = document.getElementById('userError');
+        msgEl.textContent = '';
+        errEl.textContent = '';
+        try {
+            const resp = await fetch(ServerConfig.get().baseUrl + '/users', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${ServerConfig.get().authToken}`
+                },
+                body: JSON.stringify({ email, password, role })
+            });
+            if (!resp.ok) {
+                const data = await resp.json().catch(() => ({}));
+                throw new Error(data.error || 'Failed');
+            }
+            msgEl.textContent = 'Benutzer angelegt';
+            document.getElementById('createUserForm').reset();
+            loadUsers();
+        } catch (err) {
+            errEl.textContent = err.message || 'Anlegen fehlgeschlagen';
+            console.error('createUser', err);
+        }
+    }
+
+    return { loadUsers, createUser };
 })();
 
 document.addEventListener('DOMContentLoaded', () => {
     Admin.loadUsers();
+    document.getElementById('createUserForm')?.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const email = document.getElementById('newUserEmail').value;
+        const password = document.getElementById('newUserPassword').value;
+        const role = document.getElementById('newUserRole').value;
+        Admin.createUser ? Admin.createUser(email, password, role) : createUser(email, password, role);
+    });
 });

--- a/login.html
+++ b/login.html
@@ -14,9 +14,16 @@
             <input type="password" id="loginPassword" placeholder="Passwort" required>
             <button type="submit">Login</button>
         </form>
+        <div id="loginSuccess" class="success"></div>
         <div id="loginError" class="error"></div>
     </div>
     <script src="js/server-config.js"></script>
     <script src="js/auth.js"></script>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('registered') === '1') {
+            document.getElementById('loginSuccess').textContent = 'Registrierung erfolgreich. Bitte einloggen.';
+        }
+    </script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -14,6 +14,7 @@
             <input type="password" id="regPassword" placeholder="Passwort" required>
             <button type="submit">Registrieren</button>
         </form>
+        <div id="registerSuccess" class="success"></div>
         <div id="registerError" class="error"></div>
     </div>
     <script src="js/server-config.js"></script>
@@ -29,10 +30,16 @@
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ email, password })
                 });
-                if (!resp.ok) throw new Error('Failed');
-                window.location.href = 'login.html';
+                if (!resp.ok) {
+                    const data = await resp.json().catch(() => ({}));
+                    throw new Error(data.error || 'Failed');
+                }
+                document.getElementById('registerSuccess').textContent = 'Registrierung erfolgreich! Weiterleitung ...';
+                setTimeout(() => {
+                    window.location.href = 'login.html?registered=1';
+                }, 800);
             } catch (err) {
-                document.getElementById('registerError').textContent = 'Registrierung fehlgeschlagen';
+                document.getElementById('registerError').textContent = err.message || 'Registrierung fehlgeschlagen';
             }
         });
     </script>

--- a/styles.css
+++ b/styles.css
@@ -35,6 +35,39 @@ body {
     display: none !important;
 }
 
+/* === AUTH PAGES === */
+.login-container {
+    max-width: 360px;
+    margin: 80px auto;
+    background: white;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.login-container form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.login-container h1 {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.error {
+    color: #e74c3c;
+    margin-top: 10px;
+    text-align: center;
+}
+
+.success {
+    color: #27ae60;
+    margin-top: 10px;
+    text-align: center;
+}
+
 /* === HEADER === */
 .header {
     background: white;


### PR DESCRIPTION
## Summary
- enhance auth page styling and messaging
- show registration success on login
- include success and error messages during registration
- extend admin UI to add new users
- support user creation via new POST `/users` endpoint

## Testing
- `npm install`
- `PORT=8080 node index.js &`
- `node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_684d74920d24832381afb28cc4f52dc7