### PR TITLE
Disable mandatory login

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -62,12 +62,6 @@ function adminOnly(req, res, next) {
     return res.status(403).json({ error: 'Forbidden' });
 }
 
-function ensureLoggedIn(req, res, next) {
-    if (req.session && req.session.user) {
-        return next();
-    }
-    return res.redirect('/login.html');
-}
 
 const db = new sqlite3.Database(DB_PATH);
 
@@ -231,21 +225,12 @@ app.delete('/users/:id', authMiddleware, adminOnly, (req, res) => {
     stmt.finalize();
 });
 
-app.get('/', ensureLoggedIn, (req, res) => {
+app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, '..', 'index.html'));
 });
 
-app.get('/index.html', ensureLoggedIn, (req, res) => {
+app.get('/index.html', (req, res) => {
     res.sendFile(path.join(__dirname, '..', 'index.html'));
-});
-
-app.use((req, res, next) => {
-    if (req.path.endsWith('.html') && !['/login.html', '/register.html'].includes(req.path)) {
-        if (!req.session || !req.session.user) {
-            return res.redirect('/login.html');
-        }
-    }
-    next();
 });
 
 app.use(express.static(path.join(__dirname, '..')));


### PR DESCRIPTION
## Summary
- remove `ensureLoggedIn` middleware
- allow serving HTML pages without a session

## Testing
- `npm install`
- `PORT=8080 node index.js &`
- `node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_684dbc98b15c832389bab4eda3799c28