### PR TITLE
Update Fly.io volume instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ Das Skript legt einen Testnutzer an und prüft den Login.
 3. Prüfe die Datei `fly.toml`. Darin ist die HTTP‑Service-Konfiguration samt
    Healthcheck hinterlegt. Weitere Umgebungsvariablen lassen sich bei Bedarf
    über `fly secrets` setzen.
-   Für den Upload wird ein Volume benötigt:
+   Für den Upload wird ein Volume benötigt. Wird die App mit mehreren Machines
+   betrieben, muss pro Machine ein Volume vorhanden sein. Erstelle daher die
+   Volumes einmalig (z. B. in Region `iad`):
    ```
-   flyctl volumes create uploads_data --size 1
+   flyctl volumes create uploads_data --region iad --size 1 --count 2
    ```
 4. Starte das Deployment mit
    ```


### PR DESCRIPTION
## Summary
- clarify that each machine on Fly.io needs its own `uploads_data` volume
- document how to create the volumes with region and count

## Testing
- `npm install`
- started `node index.js` and ran `node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_68540254eb3c8323b394aef0e238b447