### PR TITLE
Add clickable attachment links with absolute URLs

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -161,7 +161,8 @@ app.post('/upload', authMiddleware, upload.single('file'), (req, res) => {
     if (!req.file) {
         return res.status(400).json({ success: false, error: 'No file uploaded' });
     }
-    const url = `/uploads/${req.file.filename}`;
+    const baseUrl = `${req.protocol}://${req.get('host')}`;
+    const url = `${baseUrl}/uploads/${req.file.filename}`;
     res.json({ success: true, data: { filename: req.file.filename, url } });
 });
 

--- a/js/attachments.js
+++ b/js/attachments.js
@@ -112,14 +112,16 @@ window.Attachments = (function() {
 
                 // Datei zum Server uploaden
                 const uploadResult = await uploadFileToServer(file);
-                
+
+                const absoluteUrl = new URL(uploadResult.url, ServerConfig.get().baseUrl).href;
+
                 // Attachment zu Liste hinzufügen
                 const attachment = {
                     id: generateAttachmentId(),
                     name: file.name, // Original-Name für Anzeige
                     type: file.type,
                     size: file.size,
-                    url: uploadResult.url, // Server-URL mit korrektem Dateinamen
+                    url: absoluteUrl, // absoluter Pfad zum File
                     serverFilename: uploadResult.filename,
                     addedAt: new Date()
                 };
@@ -267,12 +269,12 @@ window.Attachments = (function() {
                 <div class="attachment-info">
                     <div class="attachment-icon">${getFileIcon(attachment.type)}</div>
                     <div class="attachment-details">
-                        <strong>${Utils.escapeHtml(attachment.name)}</strong><br>
+                        <strong><a href="${attachment.url}" target="_new">${Utils.escapeHtml(attachment.name)}</a></strong><br>
                         <small>${Utils.formatFileSize(attachment.size)} • ${getFileTypeLabel(attachment.type)}</small><br>
                         <small style="color: #4a90e2;">📁 Hochgeladen</small>
                     </div>
                 </div>
-                <button onclick="Attachments.removeAttachment('${attachment.id}')" 
+                <button onclick="Attachments.removeAttachment('${attachment.id}')"
                         class="btn-remove" title="Attachment entfernen">✕</button>
             </div>
         `).join('');
@@ -309,8 +311,8 @@ window.Attachments = (function() {
         container.innerHTML = `
             <div class="send-attachment-summary">
                 <strong>${attachments.length} Attachment(s) hochgeladen:</strong><br>
-                ${attachments.map(att => 
-                    `<small>📎 <a href="${att.url}" target="_blank">${Utils.escapeHtml(att.name)}</a> (${Utils.formatFileSize(att.size)})</small>`
+                ${attachments.map(att =>
+                    `<small>📎 <a href="${att.url}" target="_new">${Utils.escapeHtml(att.name)}</a> (${Utils.formatFileSize(att.size)})</small>`
                 ).join('<br>')}
             </div>
         `;

--- a/js/mail-wizard.js
+++ b/js/mail-wizard.js
@@ -802,7 +802,7 @@ window.MailWizard = (function() {
         
         container.innerHTML = wizardData.attachments.map(att => `
             <div class="wizard-attachment-item">
-                <span>${att.name} (${Utils.formatFileSize(att.size)})</span>
+                <span><a href="${att.url}" target="_new">${att.name}</a> (${Utils.formatFileSize(att.size)})</span>
                 <button onclick="MailWizard.insertAttachmentLink('${att.id}')" class="wizard-btn-small">
                     📝 In Text einfügen
                 </button>
@@ -818,7 +818,7 @@ window.MailWizard = (function() {
         if (!attachment) return;
         
         const editor = document.getElementById('wizardVisualEditor');
-        const linkHtml = `<p><a href="${attachment.url}" style="color: #667eea;">📎 ${attachment.name}</a> (${Utils.formatFileSize(attachment.size)})</p>`;
+        const linkHtml = `<p><a href="${attachment.url}" target="_new" style="color: #667eea;">📎 ${attachment.name}</a> (${Utils.formatFileSize(attachment.size)})</p>`;
         
         if (editor) {
             editor.innerHTML += linkHtml;


### PR DESCRIPTION
## Summary
- return absolute URL from backend upload endpoint
- show attachments as links in attachment list
- open attachment links in new tabs across the app

## Testing
- `npm run test-auth` *(fails: ECONNREFUSED – server not running)*

------
https://chatgpt.com/codex/tasks/task_e_68540da225708323952e6e771a09526c