### PR TITLE
Add attachment link placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
                             <li>Verbinde deinen E-Mail-Provider (Gmail, Outlook, etc.)</li>
                             <li>Erstelle ein Email Template mit diesen Variablen:<br>
                                 <code>{{to_name}}, {{from_name}}, {{subject}}, {{message}}</code><br>
-                                <strong>Wichtig:</strong> Für Attachments füge auch hinzu:<br>
-                                <code>{{attachment1_name}}, {{attachment1_content}}, {{attachment_count}}</code></li>
+                                <strong>Wichtig:</strong> Für Dateilinks und Anhänge füge hinzu:<br>
+                                <code>{{attachment_links}}, {{attachment1_url}}, {{attachment1_name}}, {{attachment1_content}}, {{attachment_count}}</code></li>
                             <li>Kopiere die IDs hierher</li>
                         </ol>
                     </div>
@@ -632,8 +632,8 @@
                 <h3>EmailJS Konfiguration</h3>
                 <div class="info-box">
                     <strong>💡 Tipp:</strong> Nutze den Setup Wizard für eine geführte Einrichtung!<br>
-                    <strong>📎 Attachments:</strong> Für Anhänge muss dein EmailJS Template die Variablen 
-                    <code>{{attachment1_name}}, {{attachment1_content}}, {{attachment_count}}</code> enthalten.
+                    <strong>📎 Attachments:</strong> Für Dateilinks und Anhänge nutze die Variablen
+                    <code>{{attachment_links}}, {{attachment1_url}}, {{attachment1_name}}, {{attachment1_content}}, {{attachment_count}}</code>.
                 </div>
                 
                 <div class="form-group">

--- a/js/attachments.js
+++ b/js/attachments.js
@@ -382,10 +382,18 @@ window.Attachments = (function() {
      * @returns {Object} Template-Parameter
      */
     function getEmailTemplateParams() {
-        return {
+        const params = {
             attachment_links: generateEmailAttachmentLinks(),
             attachment_count: attachments.length
         };
+
+        attachments.forEach((att, idx) => {
+            const n = idx + 1;
+            params[`attachment${n}_url`] = att.url;
+            params[`attachment${n}_name`] = att.name;
+        });
+
+        return params;
     }
 
     // ===== GETTERS =====

--- a/js/templates.js
+++ b/js/templates.js
@@ -701,10 +701,28 @@ window.Templates = (function() {
     function personalizeContent(content, recipient, subject = '') {
         if (!content) return '';
         
-        return content
+        let result = content
             .replace(/\{\{name\}\}/g, recipient.name || 'Unbekannt')
             .replace(/\{\{email\}\}/g, recipient.email || '')
             .replace(/\{\{subject\}\}/g, subject);
+
+        if (window.Attachments) {
+            const params = Attachments.getEmailTemplateParams();
+            result = result
+                .replace(/\{\{attachments\}\}/g, params.attachment_links)
+                .replace(/\{\{attachment_links\}\}/g, params.attachment_links)
+                .replace(/\{\{attachment_count\}\}/g, params.attachment_count);
+
+            for (let i = 1; i <= params.attachment_count; i++) {
+                const url = params[`attachment${i}_url`] || '';
+                const name = params[`attachment${i}_name`] || '';
+                result = result
+                    .replace(new RegExp(`\\{\\{attachment${i}_url\\}\\}`, 'g'), url)
+                    .replace(new RegExp(`\\{\\{attachment${i}_name\\}\\}`, 'g'), name);
+            }
+        }
+
+        return result;
     }
 
     // ===== TEMPLATE MANAGEMENT =====


### PR DESCRIPTION
## Summary
- allow referencing uploaded attachments directly in templates
- fill attachment placeholders when personalizing templates
- document new template variables in the setup wizard and config help

## Testing
- `npm install`
- `PORT=8080 node index.js &`
- `node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_685466d7a75083239c201aab1d6f14e7