### PR TITLE
Add attachment link insertion to template editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -544,7 +544,11 @@
                     </div>
                     <div id="attachmentStats" class="attachment-stats"></div>
                 </div>
-                
+
+                <div class="form-group">
+                    <button class="btn btn-small" onclick="Attachments.insertAttachmentList()">📋 Alle Links einfügen</button>
+                </div>
+
                 <div class="form-group">
                     <button class="btn danger" onclick="Attachments.clearAll()">🗑️ Alle Attachments entfernen</button>
                 </div>

--- a/js/attachments.js
+++ b/js/attachments.js
@@ -264,7 +264,7 @@ window.Attachments = (function() {
             return;
         }
 
-        container.innerHTML = attachments.map(attachment => `
+        container.innerHTML = attachments.map((attachment, idx) => `
             <div class="attachment-item">
                 <div class="attachment-info">
                     <div class="attachment-icon">${getFileIcon(attachment.type)}</div>
@@ -274,6 +274,7 @@ window.Attachments = (function() {
                         <small style="color: #4a90e2;">📁 Hochgeladen</small>
                     </div>
                 </div>
+                <button class="btn btn-small" onclick="Attachments.insertAttachmentLink('${attachment.id}')" title="Link einfügen">🔗</button>
                 <button onclick="Attachments.removeAttachment('${attachment.id}')"
                         class="btn-remove" title="Attachment entfernen">✕</button>
             </div>
@@ -396,6 +397,29 @@ window.Attachments = (function() {
         return params;
     }
 
+    /**
+     * Fügt einen Platzhalter-Link für ein Attachment in den Editor ein
+     * @param {string} attachmentId - ID des Attachments
+     */
+    function insertAttachmentLink(attachmentId) {
+        if (!window.Templates || typeof Templates.insertTextAtCursor !== 'function') return;
+
+        const index = attachments.findIndex(att => att.id === attachmentId);
+        if (index === -1) return;
+
+        const n = index + 1;
+        const placeholder = `<a href="{{attachment${n}_url}}">{{attachment${n}_name}}</a>`;
+        Templates.insertTextAtCursor(placeholder);
+    }
+
+    /**
+     * Fügt die Variable für die gesamte Attachment-Liste ein
+     */
+    function insertAttachmentList() {
+        if (!window.Templates || typeof Templates.insertTextAtCursor !== 'function') return;
+        Templates.insertTextAtCursor('{{attachment_links}}');
+    }
+
     // ===== GETTERS =====
 
     function getAttachments() {
@@ -442,11 +466,13 @@ window.Attachments = (function() {
         // Display functions
         updateDisplay,
         displayAttachmentList,
-        
+
         // Email integration
         generateEmailAttachmentLinks,
         getEmailTemplateParams,
-        
+        insertAttachmentLink,
+        insertAttachmentList,
+
         // Getters
         getAttachments,
         getAttachmentCount,

--- a/js/templates.js
+++ b/js/templates.js
@@ -887,6 +887,35 @@ window.Templates = (function() {
         }
     }
 
+    // ===== TEXT INSERTION =====
+
+    /**
+     * Fügt Text an der Cursor-Position des aktuell fokussierten Feldes ein
+     * @param {string} text - einzufügender Text
+     */
+    function insertTextAtCursor(text) {
+        const el = document.activeElement;
+
+        if (el && (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT')) {
+            const start = el.selectionStart || 0;
+            const end = el.selectionEnd || 0;
+            el.value = el.value.slice(0, start) + text + el.value.slice(end);
+            el.selectionStart = el.selectionEnd = start + text.length;
+            markAsChanged();
+            el.focus();
+        } else {
+            const htmlEditor = document.getElementById('htmlContent');
+            if (htmlEditor) {
+                const start = htmlEditor.selectionStart || 0;
+                const end = htmlEditor.selectionEnd || 0;
+                htmlEditor.value = htmlEditor.value.slice(0, start) + text + htmlEditor.value.slice(end);
+                htmlEditor.selectionStart = htmlEditor.selectionEnd = start + text.length;
+                markAsChanged();
+                htmlEditor.focus();
+            }
+        }
+    }
+
     // ===== PUBLIC API =====
     return {
         // Core functions
@@ -909,10 +938,11 @@ window.Templates = (function() {
         
         // Preview & personalization
         personalizeContent,
-        
+
         // Utilities
         markAsChanged,
         markAsSaved,
-        showApplyButton
+        showApplyButton,
+        insertTextAtCursor
     };
 })();


### PR DESCRIPTION
## Summary
- add UI control to insert all attachment links in template editor
- support inserting individual attachment placeholders
- enable insertion of text at cursor for template fields

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68546b11f5c88323ae4e509f59d26c41