### PR TITLE
Implement unsaved changes indicator

### DIFF
--- a/js/templates.js
+++ b/js/templates.js
@@ -868,7 +868,18 @@ window.Templates = (function() {
      * Aktualisiert Save-Button Status
      */
     function updateSaveButtonState() {
-        // TODO: Visual indicator für unsaved changes implementieren
+        const saveBtn = document.querySelector('[onclick="Templates.save()"]');
+        if (!saveBtn) return;
+
+        if (hasUnsavedChanges) {
+            saveBtn.classList.add('unsaved');
+            if (!saveBtn.textContent.includes('*')) {
+                saveBtn.textContent = '💾 Speichern*';
+            }
+        } else {
+            saveBtn.classList.remove('unsaved');
+            saveBtn.textContent = '💾 Speichern';
+        }
     }
 
     /**
@@ -877,7 +888,7 @@ window.Templates = (function() {
     function showSaveSuccess() {
         const saveBtn = document.querySelector('[onclick="Templates.save()"]');
         if (saveBtn) {
-            const originalText = saveBtn.textContent;
+            const originalText = '💾 Speichern';
             saveBtn.textContent = '✅ Gespeichert!';
             saveBtn.style.background = '#27ae60';
             setTimeout(() => {

--- a/styles.css
+++ b/styles.css
@@ -262,6 +262,14 @@ small {
     background: #c0392b;
 }
 
+.btn.unsaved {
+    background: #f39c12;
+}
+
+.btn.unsaved:hover {
+    background: #d35400;
+}
+
 .btn.btn-outline {
     background: transparent;
     border: 2px solid #4a90e2;


### PR DESCRIPTION
## Summary
- highlight save button when template has unsaved changes
- keep save button text consistent when showing the save success message
- style `.btn.unsaved` in CSS for orange warning color

## Testing
- `npm run test-auth` *(fails: server dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68546fe7139c83238cdf76eab25c4593