### PR TITLE
Improve auth pages with new gradient style

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -7,6 +7,9 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <header class="simple-header">
+        <a href="index.html" class="logo">🐦 pigeon.run</a>
+    </header>
     <div class="login-container">
         <h1>Benutzerverwaltung</h1>
         <table id="userTable">

--- a/login.html
+++ b/login.html
@@ -7,6 +7,9 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <header class="simple-header">
+        <a href="index.html" class="logo">🐦 pigeon.run</a>
+    </header>
     <div class="login-container">
         <h1>Login</h1>
         <form id="loginForm">

--- a/register.html
+++ b/register.html
@@ -7,6 +7,9 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <header class="simple-header">
+        <a href="index.html" class="logo">🐦 pigeon.run</a>
+    </header>
     <div class="login-container">
         <h1>Registrieren</h1>
         <form id="registerForm">

--- a/styles.css
+++ b/styles.css
@@ -10,10 +10,11 @@
 }
 
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    background: #f5f7fa;
-    color: #333;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     line-height: 1.6;
+    color: #2d3748;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    min-height: 100vh;
 }
 
 /* === LAYOUT === */
@@ -35,14 +36,36 @@ body {
     display: none !important;
 }
 
+/* === SIMPLE HEADER === */
+.simple-header {
+    padding: 40px 0;
+    text-align: center;
+    color: white;
+}
+
+.logo {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 2rem;
+    font-weight: 700;
+    text-decoration: none;
+    color: inherit;
+}
+
+.logo:hover {
+    transform: translateY(-2px);
+    transition: transform 0.2s ease;
+}
+
 /* === AUTH PAGES === */
 .login-container {
     max-width: 360px;
     margin: 80px auto;
     background: white;
     padding: 30px;
-    border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    border-radius: 20px;
+    box-shadow: 0 20px 40px rgba(0,0,0,0.1);
 }
 
 .login-container form {


### PR DESCRIPTION
## Summary
- use gradient background and modern fonts in base styles
- tweak auth pages to include a simple header with pigeon.run branding
- round login cards and add subtle shadow for a card-like look

## Testing
- `npm install` *(backend)*
- `PORT=8080 node index.js &` *(in backend)*
- `node test-auth.js`


------
https://chatgpt.com/codex/tasks/task_e_685557493f208323b6c1f5d2273821b0