### PR TITLE
Enhance mail wizard setup handling

### DIFF
--- a/js/landing.js
+++ b/js/landing.js
@@ -58,28 +58,25 @@ function showTemplateEditor() {
  */
 function showMailWizard() {
     try {
-        // Prüfe Setup-Status
+        // Erweiterte Setup-Prüfung
         const isConfigured = localStorage.getItem('emailjs_configured') === 'true';
-        
-        if (!isConfigured) {
+        const serviceId = localStorage.getItem('emailjs_service_id');
+
+        if (!isConfigured || !serviceId) {
             if (confirm('Setup noch nicht abgeschlossen. Jetzt konfigurieren?')) {
                 startSetup();
                 return;
+            } else {
+                return; // Abbruch
             }
         }
-        
+
         // Mail Wizard starten
         if (window.MailWizard && typeof window.MailWizard.startWizard === 'function') {
             console.log('Starting mail wizard...');
             window.MailWizard.startWizard();
-        } else if (window.App && typeof window.App.showTab === 'function') {
-            // Fallback: Zur Mail-Tab wechseln
-            console.log('MailWizard module not found, switching to mail tab');
-            window.App.showTab('mail');
         } else {
-            // Letzter Fallback: Navigation
-            console.log('Using fallback navigation to mail page');
-            window.location.href = '/app.html#mail';
+            alert('Mail Wizard wird geladen...');
         }
     } catch (error) {
         console.error('Error starting mail wizard:', error);

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -492,6 +492,11 @@ window.Wizard = (function() {
         const success = Config.saveConfig(config);
         
         if (success) {
+            // WICHTIG: Setup-Status für Landing Page setzen
+            localStorage.setItem('emailjs_configured', 'true');
+            localStorage.setItem('emailjs_service_id', config.serviceId);
+            localStorage.setItem('fromName', config.fromName);
+            
             // Hauptkonfiguration auch aktualisieren
             updateMainConfigUI(config);
             console.log('Wizard config saved successfully');
@@ -525,19 +530,16 @@ window.Wizard = (function() {
      */
     function finishSetup() {
         try {
+            // Sicherstellen, dass Config gespeichert ist
+            saveWizardConfig();
+            
             // Wizard verstecken
             hide();
             
-            // Setup-Prompt verstecken
-            Utils.toggleElement('setupPrompt', false);
-            
-            // Hauptanwendung initialisieren
-            if (window.App && typeof App.checkSetupStatus === 'function') {
-                // App über Setup-Abschluss informieren
+            // Landing Page über Setup-Abschluss informieren
+            if (window.checkSetupStatus) {
                 setTimeout(() => {
-                    if (Config) {
-                        Config.updateConfigUI();
-                    }
+                    window.checkSetupStatus();
                 }, 100);
             }
             


### PR DESCRIPTION
## Summary
- persist wizard configuration to `localStorage`
- trigger setup save on wizard completion and notify landing page
- improve wizard launch checks on landing page

## Testing
- `npm --prefix backend run test-auth` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68564c185694832397b4e5847e078df8