### PR TITLE
Add automatic versioning with footer display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ backend/db.sqlite
 backend/uploads/
 # MacOS DS_Store
 .DS_Store
+
+# Version files (werden automatisch generiert)
+version.txt
+version.json

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "prestart": "node ../generate-version.js",
+    "start": "node index.js",
+    "prebuild": "node ../generate-version.js",
+    "build": "echo 'Build complete'",
+    "dev": "node ../generate-version.js && node index.js",
+    "version": "node ../generate-version.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test-auth": "node test-auth.js"
   },

--- a/fly.toml
+++ b/fly.toml
@@ -3,7 +3,13 @@ primary_region = "iad"
 
 
 [build]
-  dockerfile = "Dockerfile"
+  builder = "paketobuildpacks/builder:base"
+
+[build.args]
+  NODE_VERSION = "18"
+
+[[build.env]]
+  NODE_ENV = "production"
 
 [http_service]
   internal_port       = 8080

--- a/generate-version.js
+++ b/generate-version.js
@@ -1,23 +1,104 @@
 const fs = require('fs');
 const { execSync } = require('child_process');
-const path = require('path');
-const pkg = require('./backend/package.json');
 
-function git(cmd) {
-  try {
-    return execSync(cmd).toString().trim();
-  } catch (e) {
-    return '';
-  }
+function generateVersion() {
+    try {
+        // Datum und Zeit
+        const now = new Date();
+        const dateStr = now.toISOString().slice(0, 19).replace('T', ' ');
+        const timestamp = Math.floor(now.getTime() / 1000);
+        
+        // Git-Informationen (falls verfügbar)
+        let gitCommit = 'unknown';
+        let gitBranch = 'unknown';
+        
+        try {
+            gitCommit = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+            gitBranch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+        } catch (e) {
+            console.log('Git info not available, using defaults');
+        }
+        
+        // Build-Nummer basierend auf Timestamp
+        const buildNumber = timestamp.toString().slice(-6); // Letzte 6 Ziffern
+        
+        // Version-String generieren
+        const majorMinor = '1.0'; // Kann manuell erhöht werden
+        const version = `${majorMinor}.${buildNumber}`;
+        const fullVersion = `${version} (${dateStr} - ${gitCommit})`;
+        
+        // Version-Objekt erstellen
+        const versionData = {
+            version: version,
+            fullVersion: fullVersion,
+            buildDate: dateStr,
+            gitCommit: gitCommit,
+            gitBranch: gitBranch,
+            buildNumber: buildNumber,
+            timestamp: timestamp
+        };
+        
+        // version.txt für einfachen Zugriff
+        fs.writeFileSync('version.txt', fullVersion);
+        
+        // version.json für JavaScript-Zugriff
+        fs.writeFileSync('version.json', JSON.stringify(versionData, null, 2));
+        
+        // js/version.js aktualisieren
+        const versionJs = `// Auto-generated version file
+window.APP_VERSION = ${JSON.stringify(versionData)};
+
+// Version display function
+function displayVersion() {
+    const versionElements = document.querySelectorAll('.app-version');
+    versionElements.forEach(el => {
+        if (el.classList.contains('version-short')) {
+            el.textContent = window.APP_VERSION.version;
+        } else if (el.classList.contains('version-full')) {
+            el.textContent = window.APP_VERSION.fullVersion;
+        } else {
+            el.textContent = window.APP_VERSION.version;
+        }
+
+        // Tooltip mit vollständigen Informationen
+        el.title = 'Version: ' + window.APP_VERSION.version +
+            '\\nBuild: ' + window.APP_VERSION.buildDate +
+            '\\nCommit: ' + window.APP_VERSION.gitCommit +
+            '\\nBranch: ' + window.APP_VERSION.gitBranch;
+    });
 }
 
-const commit = git('git rev-parse --short HEAD') || 'unknown';
-let dirty = '';
-try {
-  if (git('git status --porcelain')) dirty = '-dirty';
-} catch {}
-const date = new Date().toISOString().split('T')[0];
-const version = `${pkg.version} (${commit}${dirty}, ${date})`;
-fs.writeFileSync(path.join(__dirname, 'version.txt'), version + '\n');
-console.log('Generated version:', version);
+// Auto-initialize when DOM is ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', displayVersion);
+} else {
+    displayVersion();
+}
 
+console.log('App Version:', window.APP_VERSION.version);
+`;
+        
+        fs.writeFileSync('js/version.js', versionJs);
+        
+        console.log('\u2713 Version generated:', version);
+        console.log('\u2713 Build date:', dateStr);
+        console.log('\u2713 Git commit:', gitCommit);
+        
+    } catch (error) {
+        console.error('Error generating version:', error);
+        
+        // Fallback-Version bei Fehlern
+        const fallbackVersion = '1.0.0';
+        const fallbackDate = new Date().toISOString().slice(0, 19).replace('T', ' ');
+        
+        fs.writeFileSync('version.txt', `${fallbackVersion} (${fallbackDate} - fallback)`);
+        fs.writeFileSync('js/version.js', `window.APP_VERSION = {version: "${fallbackVersion}", buildDate: "${fallbackDate}"};`);
+    }
+}
+
+// Direkt ausführen wenn als Script aufgerufen
+if (require.main === module) {
+    generateVersion();
+}
+
+module.exports = generateVersion;

--- a/index.html
+++ b/index.html
@@ -76,13 +76,23 @@
         </main>
     </div>
 
-    <!-- Footer -->
-    <footer class="footer">
-        <p>
-            <strong>pigeon.run</strong> - Open Source E-Mail Marketing Tool<br>
-            <small>Läuft vollständig in deinem Browser • Keine Daten verlassen dein System • Version <span id="version">lade...</span></small>
-        </p>
+    <!-- Footer mit Version -->
+    <footer class="app-footer">
+        <div class="footer-content">
+            <div class="footer-left">
+                <span class="footer-brand">🐦 pigeon.run</span>
+                <span class="footer-desc">Self-Hosted Email Marketing</span>
+            </div>
+            <div class="footer-right">
+                <span class="version-info">
+                    Version: <span class="app-version version-short">loading...</span>
+                </span>
+            </div>
+        </div>
     </footer>
+
+    <!-- Version Script (lade als erstes) -->
+    <script src="js/version.js"></script>
 
     <!-- Setup Wizard Modal (vor </body>) -->
     <div id="setupWizard" class="wizard-overlay hidden">
@@ -433,7 +443,6 @@
     <script src="js/recipients.js"></script>
     <script src="js/sender.js"></script>
     <script src="js/attachments.js"></script>
-    <script src="js/version.js"></script>
 
     <!-- External Dependencies -->
     <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"></script>

--- a/landing.css
+++ b/landing.css
@@ -582,3 +582,75 @@ body {
     border-color: #4a90e2;
     background: #e3f2fd;
 }
+
+/* App Footer */
+.app-footer {
+    margin-top: 50px;
+    padding: 20px 0;
+    border-top: 1px solid #e5e7eb;
+    background: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(10px);
+}
+
+.footer-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 15px;
+}
+
+.footer-left {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.footer-brand {
+    font-weight: 600;
+    font-size: 18px;
+    color: #1e293b;
+}
+
+.footer-desc {
+    color: #64748b;
+    font-size: 14px;
+}
+
+.footer-right {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}
+
+.version-info {
+    font-size: 13px;
+    color: #6b7280;
+    font-family: 'Courier New', monospace;
+    padding: 4px 8px;
+    background: #f3f4f6;
+    border-radius: 4px;
+    cursor: help;
+}
+
+.app-version {
+    font-weight: 600;
+    color: #374151;
+}
+
+/* Responsive Footer */
+@media (max-width: 768px) {
+    .footer-content {
+        flex-direction: column;
+        text-align: center;
+        gap: 10px;
+    }
+    
+    .footer-left {
+        flex-direction: column;
+        gap: 5px;
+    }
+}


### PR DESCRIPTION
## Summary
- implement new `generate-version.js` script for automatic build metadata
- call version generator from backend npm scripts
- add footer with version info and hook up `version.js`
- style new footer in `landing.css`
- configure Fly buildpack and ignore generated version files

## Testing
- `node generate-version.js`


------
https://chatgpt.com/codex/tasks/task_e_6856541e8ccc8323a914608c65ca317c