### PR TITLE
Fix version display script

### DIFF
--- a/js/version.js
+++ b/js/version.js
@@ -1,21 +1,25 @@
+// Auto-generated version file
+window.APP_VERSION = {"version":"1.0.490248","fullVersion":"1.0.490248 (2025-06-21 07:17:28)","buildDate":"2025-06-21 07:17:28","buildNumber":"490248","timestamp":1750490248};
 
-document.addEventListener('DOMContentLoaded', () => {
-  fetch('version.txt')
-    .then(res => res.text())
-    .then(text => {
-      const el = document.getElementById('version');
-      if (el) {
-        const raw = text.trim();
-        const match = raw.match(/^(\S+)\s+\((.+)\)$/);
-        if (match) {
-          el.textContent = match[1];
-          el.title = match[2];
+function displayVersion() {
+    const versionElements = document.querySelectorAll('.app-version');
+    versionElements.forEach(el => {
+        if (el.classList.contains('version-short')) {
+            el.textContent = window.APP_VERSION.version;
+        } else if (el.classList.contains('version-full')) {
+            el.textContent = window.APP_VERSION.fullVersion;
         } else {
-          el.textContent = raw;
+            el.textContent = window.APP_VERSION.version;
         }
-      }
-    })
-    .catch(err => console.error('Failed to load version', err));
-});
+        el.title = `Version: ${window.APP_VERSION.version}
+Build: ${window.APP_VERSION.buildDate}`;
+    });
+}
 
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', displayVersion);
+} else {
+    displayVersion();
+}
 
+console.log('App Version:', window.APP_VERSION.version);


### PR DESCRIPTION
## Summary
- update `version.js` to use `.app-version` selector
- regenerate version info with `generate-version.js`

## Testing
- `npm install` in `backend`
- `PORT=8080 node index.js &`
- `node test-auth.js`


------
https://chatgpt.com/codex/tasks/task_e_68565c5f868483239d7ceacc7ec62df7