### PR TITLE
Fix broken recipients/history links

### DIFF
--- a/js/landing.js
+++ b/js/landing.js
@@ -93,7 +93,6 @@ function showRecipients() {
         } else {
             // Fallback: Navigation
             console.log('App module not found, using fallback navigation');
-            window.location.href = '/app.html#recipients';
         }
     } catch (error) {
         console.error('Error opening recipients:', error);
@@ -115,7 +114,6 @@ function showHistory() {
         } else {
             // Fallback: Navigation
             console.log('App module not found, using fallback navigation');
-            window.location.href = '/app.html#history';
         }
     } catch (error) {
         console.error('Error opening history:', error);


### PR DESCRIPTION
## Summary
- remove leftover navigation to `/app.html` in `showRecipients()` and `showHistory()`

## Testing
- `npm install --silent`
- `PORT=8080 node index.js >server.log 2>&1 &`
- `node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_685687d4e3bc832389036273ff6503f6