### PR TITLE
Fix load order and init timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,14 +311,14 @@
     <!-- Mail Wizard -->
     <script src="js/mail-wizard.js"></script>
 
-    <!-- Main Application Controller -->
-    <script src="js/app.js"></script>
-
-    <!-- Additional Modules (falls vorhanden) -->
+    <!-- Zusätzliche Module vor der App laden -->
     <script src="js/templates.js"></script>
     <script src="js/recipients.js"></script>
     <script src="js/sender.js"></script>
     <script src="js/attachments.js"></script>
+
+    <!-- Main Application Controller (nach allen Modulen) -->
+    <script src="js/app.js"></script>
 
     <!-- External Dependencies -->
     <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -594,15 +594,7 @@ ${error.stack}
 
 // ===== AUTO-INITIALIZATION =====
 // App automatisch initialisieren wenn DOM ready
+// Initialisierung erst nach kompletter DOM-Ladung
 document.addEventListener('DOMContentLoaded', () => {
     App.init();
 });
-
-// Fallback für bereits geladenes DOM
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => {
-        App.init();
-    });
-} else {
-    App.init();
-}


### PR DESCRIPTION
## Summary
- load feature modules before the main `app.js`
- initialize the app only once after DOM is ready

## Testing
- `PORT=8080 node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_685691fc76d08323bc530c14ba3e3894