### PR TITLE
Bump version to 2.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "bcryptjs": "^3.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/generate-version.js
+++ b/generate-version.js
@@ -6,7 +6,7 @@ function generateVersion() {
         const dateStr = now.toISOString().slice(0, 19).replace('T', ' ');
         const timestamp = Math.floor(now.getTime() / 1000);
         const buildNumber = timestamp.toString().slice(-6);
-        const version = `1.0.${buildNumber}`;
+        const version = `2.0.${buildNumber}`;
         const fullVersion = `${version} (${dateStr})`;
         
         const versionData = {
@@ -51,7 +51,7 @@ console.log('App Version:', window.APP_VERSION.version);
         
     } catch (error) {
         console.error('Error generating version:', error);
-        const fallbackVersion = '1.0.0';
+        const fallbackVersion = '2.0.0';
         const fallbackDate = new Date().toISOString().slice(0, 19).replace('T', ' ');
         const fallback = `${fallbackVersion} (${fallbackDate})`;
         fs.writeFileSync('version.txt', fallback);

--- a/js/config.js
+++ b/js/config.js
@@ -20,7 +20,7 @@ window.Config = (function() {
         userId: '',
         fromName: '',
         setupCompleted: false,
-        version: '1.0'
+        version: '2.0'
     };
 
     const DEFAULT_SETTINGS = {
@@ -337,7 +337,7 @@ window.Config = (function() {
     function createBackup() {
         try {
             return {
-                version: '1.0',
+                version: '2.0',
                 timestamp: new Date().toISOString(),
                 created: Utils.formatDate(new Date()),
                 emailConfig: currentConfig,

--- a/js/version.js
+++ b/js/version.js
@@ -1,5 +1,5 @@
 // Auto-generated version file
-window.APP_VERSION = {"version":"1.0.490248","fullVersion":"1.0.490248 (2025-06-21 07:17:28)","buildDate":"2025-06-21 07:17:28","buildNumber":"490248","timestamp":1750490248};
+window.APP_VERSION = {"version":"2.0.507756","fullVersion":"2.0.507756 (2025-06-21 12:09:16)","buildDate":"2025-06-21 12:09:16","buildNumber":"507756","timestamp":1750507756};
 
 function displayVersion() {
     const versionElements = document.querySelectorAll('.app-version');


### PR DESCRIPTION
## Summary
- update base version in `generate-version.js`
- bump `backend` package version to 2.0.0
- align lockfile version
- reflect new version in default client config
- regenerate `js/version.js`

## Testing
- `node generate-version.js`
- `PORT=8080 node backend/index.js` *(fails: Cannot find module 'express')*
- `node backend/test-auth.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0866c1883238fe8daa178102b44