### PR TITLE
Fix default dashboard, button style, and widen wizard modal

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -156,7 +156,8 @@ window.App = (function() {
      */
     function showInitialInterface() {
         // Aktiven Tab setzen
-        showTab(currentTab);
+        // Dashboard immer als initialen Tab anzeigen
+        showTab('dashboard');
         
         // Template-Preview aktualisieren wenn Templates-Modul verfügbar
         if (modules.templates && typeof modules.templates.updatePreview === 'function') {

--- a/js/landing.js
+++ b/js/landing.js
@@ -151,7 +151,7 @@ function checkSetupStatus() {
                     <div class="status-desc">Bereit für E-Mail-Kampagnen</div>
                     <div class="status-details">Service: ${serviceId.substring(0, 15)}... | Von: ${fromName}</div>
                 </div>
-                <button class="btn-primary" onclick="showMailWizard()">
+                <button class="btn btn-primary" onclick="showMailWizard()">
                     Kampagne starten
                 </button>
             `;

--- a/styles.css
+++ b/styles.css
@@ -618,6 +618,21 @@ small {
     overflow: hidden;
 }
 
+/* Generic modal container used for wizards */
+.wizard-modal {
+    background: white;
+    border-radius: 15px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+    width: 90%;
+    max-width: 600px;
+    max-height: 80vh;
+    overflow: hidden;
+}
+
+.wizard-modal.large {
+    max-width: 1000px;
+}
+
 .wizard-header {
     background: linear-gradient(135deg, #4a90e2, #357abd);
     color: white;
@@ -1508,7 +1523,7 @@ small {
         gap: 15px !important;
     }
 
-    .wizard-container, .mail-wizard-container {
+    .wizard-container, .mail-wizard-container, .wizard-modal {
         width: 95%;
         max-height: 90vh;
     }


### PR DESCRIPTION
## Summary
- force dashboard tab on initial load
- style "Kampagne starten" button with unified btn-primary
- add wizard modal styling and increase width for mail wizard

## Testing
- `npm install`
- `PORT=8080 node index.js &`
- `node test-auth.js`


------
https://chatgpt.com/codex/tasks/task_e_6856a160669083238131b64cc40dc46b