### PR TITLE
Fix preview layout so editor and preview are side-by-side

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
                         <div id="htmlEditor" style="display: none;">
                             <textarea id="htmlContent" class="editor"></textarea>
                         </div>
-                        <div id="preview" class="preview" style="grid-column: span 2;"></div>
+                        <div id="preview" class="preview"></div>
                     </div>
 
                     <div id="templateStatus"></div>

--- a/styles.css
+++ b/styles.css
@@ -317,10 +317,11 @@ small {
 
 /* Container for editor and preview */
 .template-editor-container {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px;
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 20px !important;
     margin-top: 15px;
+    min-height: 500px;
 }
 
 /* === EDITORS === */
@@ -332,14 +333,19 @@ small {
     resize: vertical;
 }
 
+#simpleEditor,
+#htmlEditor {
+    min-height: 500px;
+}
+
 .preview {
+    min-height: 500px;
+    max-height: 500px;
+    overflow-y: auto;
     border: 2px solid #e0e6ed;
     border-radius: 6px;
     padding: 20px;
     background: white;
-    min-height: 400px;
-    max-height: 500px;
-    overflow-y: auto;
 }
 
 #templateFields {
@@ -1510,7 +1516,8 @@ small {
     }
 
     .template-editor-container {
-        grid-template-columns: 1fr !important;
+        grid-template-columns: 1fr 1fr !important;
+        gap: 15px;
     }
     
     .recipient-input {


### PR DESCRIPTION
## Summary
- keep preview beside the editor even on smaller screens
- update template editor CSS styles
- remove `grid-column` from preview element

## Testing
- `npm install` (backend)
- `PORT=8080 node index.js & NODE_PID=$!; sleep 1; node test-auth.js; kill $NODE_PID`

------
https://chatgpt.com/codex/tasks/task_e_6856a2a49d4483239a99287b74b1b6c7