### PR TITLE
Implement recipients tab and wizard integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
 
                     <!-- CSV Import Bereich -->
                     <div class="section">
-                        <h3>CSV-Datei importieren</h3>
+                        <h3>📁 CSV-Datei importieren</h3>
                         <div class="csv-import-container">
                             <input type="file" id="csvFileInput" accept=".csv" style="display: none;">
                             <div class="csv-drop-zone" onclick="document.getElementById('csvFileInput').click();">
@@ -152,6 +152,24 @@
                                 </div>
                             </div>
                             <button class="btn btn-secondary" onclick="Recipients.loadTestData()">📋 Test-Daten laden</button>
+                        </div>
+                    </div>
+
+                    <!-- Manueller Empfänger-Input -->
+                    <div class="section">
+                        <h3>✍️ Empfänger manuell hinzufügen</h3>
+                        <div class="manual-input-container">
+                            <div class="manual-input-form">
+                                <div class="form-group">
+                                    <label for="manualRecipientName">Name</label>
+                                    <input type="text" id="manualRecipientName" placeholder="Max Mustermann" class="form-control">
+                                </div>
+                                <div class="form-group">
+                                    <label for="manualRecipientEmail">E-Mail *</label>
+                                    <input type="email" id="manualRecipientEmail" placeholder="max@example.com" class="form-control" required>
+                                </div>
+                                <button class="btn btn-primary" onclick="Recipients.addManualRecipient()">➕ Hinzufügen</button>
+                            </div>
                         </div>
                     </div>
 

--- a/js/mail-wizard.js
+++ b/js/mail-wizard.js
@@ -491,7 +491,7 @@ window.MailWizard = (function() {
                 break;
             case 4:
                 // Empfänger Schritt - Empfänger laden
-                loadRecipients();
+                loadRecipientsIntoWizard();
                 break;
             case 5:
                 // Anhänge Schritt - Drop-Zone initialisieren
@@ -507,10 +507,56 @@ window.MailWizard = (function() {
     /**
      * Lädt Empfänger-Liste
      */
-    function loadRecipients() {
-        const list = document.getElementById('wizardRecipientList');
-        if (list) {
-            list.innerHTML = '<p>Empfänger-System wird implementiert...</p>';
+    function loadRecipientsIntoWizard() {
+        if (!window.Recipients) {
+            console.warn('Recipients module not available');
+            return;
+        }
+
+        const allRecipients = Recipients.getAll();
+        const recipientCount = allRecipients.length;
+
+        const selectedSpan = document.querySelector('.wizard-recipient-stats .stat-number');
+        const totalSpan = document.querySelectorAll('.wizard-recipient-stats .stat-number')[1];
+
+        if (totalSpan) {
+            totalSpan.textContent = recipientCount;
+        }
+
+        const listContainer = document.getElementById('wizardRecipientList');
+        if (!listContainer) return;
+
+        if (recipientCount === 0) {
+            listContainer.innerHTML = `
+                <div class="wizard-empty-recipients">
+                    <p>Keine Empfänger verfügbar.</p>
+                    <p><a href="#" onclick="App.showTab('recipients')">Gehen Sie zum Recipients-Tab um Empfänger hinzuzufügen.</a></p>
+                </div>
+            `;
+            return;
+        }
+
+        listContainer.innerHTML = allRecipients.map((recipient, index) => `
+            <div class="wizard-recipient-item">
+                <label class="wizard-recipient-checkbox">
+                    <input type="checkbox" value="${index}" onchange="updateRecipientSelection()">
+                    <span class="checkmark"></span>
+                </label>
+                <div class="wizard-recipient-info">
+                    <div class="wizard-recipient-name">${Utils.escapeHtml(recipient.name)}</div>
+                    <div class="wizard-recipient-email">${Utils.escapeHtml(recipient.email)}</div>
+                </div>
+            </div>
+        `).join('');
+    }
+
+    function updateRecipientSelection() {
+        const checkboxes = document.querySelectorAll('#wizardRecipientList input[type="checkbox"]');
+        const selectedCount = Array.from(checkboxes).filter(cb => cb.checked).length;
+
+        const selectedSpan = document.querySelector('.wizard-recipient-stats .stat-number');
+        if (selectedSpan) {
+            selectedSpan.textContent = selectedCount;
         }
     }
 

--- a/js/recipients.js
+++ b/js/recipients.js
@@ -40,28 +40,28 @@ window.Recipients = (function() {
      */
     function setupEventListeners() {
         // CSV File Input
-        const csvFile = document.getElementById('csvFile');
+        const csvFile = document.getElementById('csvFileInput');
         if (csvFile) {
             csvFile.addEventListener('change', loadCSV);
         }
 
         // Enter-Key Shortcuts für manuelle Eingabe
-        const manualEmail = document.getElementById('manualEmail');
+        const manualEmail = document.getElementById('manualRecipientEmail');
         if (manualEmail) {
             manualEmail.addEventListener('keypress', (e) => {
                 if (e.key === 'Enter') {
                     e.preventDefault();
-                    addManual();
+                    addManualRecipient();
                 }
             });
         }
 
-        const manualName = document.getElementById('manualName');
+        const manualName = document.getElementById('manualRecipientName');
         if (manualName) {
             manualName.addEventListener('keypress', (e) => {
                 if (e.key === 'Enter') {
                     e.preventDefault();
-                    Utils.focusElement('manualEmail');
+                    Utils.focusElement('manualRecipientEmail');
                 }
             });
         }
@@ -376,61 +376,48 @@ window.Recipients = (function() {
     /**
      * Fügt manuellen Empfänger hinzu
      */
-    function addManual() {
-        const nameInput = document.getElementById('manualName');
-        const emailInput = document.getElementById('manualEmail');
-        
-        if (!emailInput) {
-            console.error('Manual email input not found');
-            Utils.showStatus('recipientStatus', 'E-Mail-Eingabefeld nicht gefunden', 'error');
+    function addManualRecipient() {
+        const nameInput = document.getElementById('manualRecipientName');
+        const emailInput = document.getElementById('manualRecipientEmail');
+
+        if (!emailInput || !emailInput.value.trim()) {
+            alert('Bitte geben Sie eine E-Mail-Adresse ein.');
             return;
         }
 
-        const email = emailInput.value.trim();
         const name = nameInput ? nameInput.value.trim() : '';
-        
-        // Debug-Log für Troubleshooting
-        console.log('Adding manual recipient:', { email, name, emailLength: email.length });
-        
-        // Validierung mit besseren Fehlermeldungen
-        if (!email) {
-            Utils.showStatus('recipientStatus', 'Bitte E-Mail-Adresse eingeben', 'error');
-            Utils.focusElement('manualEmail');
+        const email = emailInput.value.trim();
+
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(email)) {
+            alert('Bitte geben Sie eine gültige E-Mail-Adresse ein.');
             return;
         }
-        
-        if (!Utils.isValidEmail(email)) {
-            Utils.showStatus('recipientStatus', `"${email}" ist keine gültige E-Mail-Adresse`, 'error');
-            Utils.focusElement('manualEmail');
+
+        if (recipients.some(r => r.email.toLowerCase() === email.toLowerCase())) {
+            alert('Diese E-Mail-Adresse ist bereits vorhanden.');
             return;
         }
-        
-        if (isEmailExists(email)) {
-            Utils.showStatus('recipientStatus', `E-Mail-Adresse "${email}" bereits vorhanden`, 'error');
-            Utils.focusElement('manualEmail');
-            return;
-        }
-        
-        // Empfänger hinzufügen
-        recipients.push({
-            id: recipients.length,
+
+        const newRecipient = {
             name: name || Utils.getNameFromEmail(email),
             email: email,
             status: 'pending',
             source: 'manual'
-        });
-        
-        // UI zurücksetzen
-        if (nameInput) nameInput.value = '';
-        emailInput.value = '';
-        Utils.focusElement('manualName');
-        
+        };
+
+        recipients.push(newRecipient);
         updateDisplay();
         persistRecipients();
-        
-        // Erfolgs-Nachricht
-        Utils.showStatus('recipientStatus', `✅ "${email}" hinzugefügt`, 'success');
-        console.log(`Manual recipient added: ${email}`);
+
+        if (nameInput) nameInput.value = '';
+        if (emailInput) emailInput.value = '';
+
+        Utils.showStatus('recipientStatus', `Empfänger ${email} hinzugefügt`, 'success');
+    }
+
+    function addManual() {
+        addManualRecipient();
     }
 
     /**
@@ -709,6 +696,10 @@ window.Recipients = (function() {
         return [...recipients]; // Kopie zurückgeben
     }
 
+    function getAll() {
+        return getRecipients();
+    }
+
     /**
      * Gibt Empfänger-Anzahl zurück
      * @returns {number} Anzahl Empfänger
@@ -750,6 +741,7 @@ window.Recipients = (function() {
         // Import functions
         loadCSV,
         processCSVFile,
+        addManualRecipient,
         addManual,
         loadTestData,
         
@@ -767,6 +759,7 @@ window.Recipients = (function() {
         
         // Getters
         getRecipients,
+        getAll,
         getRecipientCount,
         getStats,
         getRecipientByEmail,

--- a/styles.css
+++ b/styles.css
@@ -461,6 +461,33 @@ small {
     color: #6c757d;
 }
 
+/* === MANUAL INPUT === */
+.manual-input-container {
+    background: #f8f9fa;
+    border: 2px solid #e9ecef;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 30px;
+}
+
+.manual-input-form {
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    gap: 15px;
+    align-items: end;
+}
+
+.manual-input-form .form-group {
+    margin-bottom: 0;
+}
+
+@media (max-width: 768px) {
+    .manual-input-form {
+        grid-template-columns: 1fr;
+        gap: 15px;
+    }
+}
+
 /* === RECIPIENT CONTROLS === */
 .recipient-controls {
     display: flex;


### PR DESCRIPTION
## Summary
- add manual recipient form to **Recipients** tab
- style manual recipient input elements
- update Recipients module for new manual recipient fields
- expose `getAll()` for external access
- hook recipients into Mail Wizard step 4

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6858fe3143308323b0f841502eaf2af6