### PR TITLE
Add campaign sending interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,8 +198,132 @@
             <!-- Mail Wizard Tab -->
             <div id="mailwizard" class="tab-content">
                 <main class="main-card">
-                    <h2>Mail Wizard</h2>
-                    <p>Kampagnen-Assistent startet hier.</p>
+                    <h2>🚀 E-Mail Kampagne</h2>
+
+                    <!-- Kampagnen-Daten Anzeige -->
+                    <div id="campaignDataContainer" class="section" style="display: none;">
+                        <h3>📋 Kampagnen-Übersicht</h3>
+                        <div class="campaign-summary">
+                            <div class="campaign-info-grid">
+                                <div class="campaign-info-item">
+                                    <label>📧 Betreff:</label>
+                                    <span id="campaignSubject">-</span>
+                                </div>
+                                <div class="campaign-info-item">
+                                    <label>📄 Template:</label>
+                                    <span id="campaignTemplate">-</span>
+                                </div>
+                                <div class="campaign-info-item">
+                                    <label>👥 Empfänger:</label>
+                                    <span id="campaignRecipientCount">0</span>
+                                </div>
+                                <div class="campaign-info-item">
+                                    <label>📎 Anhänge:</label>
+                                    <span id="campaignAttachmentCount">0</span>
+                                </div>
+                            </div>
+
+                            <!-- Empfänger-Liste Preview -->
+                            <div class="campaign-recipients-preview">
+                                <h4>Empfänger-Liste:</h4>
+                                <div id="campaignRecipientsList" class="recipient-preview-list"></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Versand-Kontrollen -->
+                    <div id="sendControlsContainer" class="section" style="display: none;">
+                        <h3>📤 Versand-Einstellungen</h3>
+                        <div class="send-controls">
+                            <div class="send-options">
+                                <div class="form-group">
+                                    <label for="sendDelay">Verzögerung zwischen E-Mails (Sekunden):</label>
+                                    <input type="number" id="sendDelay" value="2" min="1" max="10" class="form-control" style="width: 100px;">
+                                    <small>Empfohlen: 2-5 Sekunden um Spam-Filter zu vermeiden</small>
+                                </div>
+
+                                <div class="form-group">
+                                    <label>
+                                        <input type="checkbox" id="testModeCheckbox" checked>
+                                        Test-Modus (sendet nur an erste 3 Empfänger)
+                                    </label>
+                                </div>
+                            </div>
+
+                            <div class="send-actions">
+                                <button id="startCampaignBtn" class="btn btn-success btn-large" onclick="CampaignSender.startCampaign()">
+                                    🚀 Kampagne starten
+                                </button>
+                                <button id="previewEmailBtn" class="btn btn-secondary" onclick="CampaignSender.showPreview()">
+                                    👁️ E-Mail Vorschau
+                                </button>
+                                <button id="newCampaignBtn" class="btn btn-primary" onclick="showMailWizard()" style="display: none;">
+                                    ➕ Neue Kampagne
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Versand-Progress -->
+                    <div id="sendProgressContainer" class="section" style="display: none;">
+                        <h3>📊 Versand-Fortschritt</h3>
+                        <div class="progress-container">
+                            <div class="progress-bar-container">
+                                <div id="sendProgressBar" class="progress-bar" style="width: 0%;"></div>
+                            </div>
+                            <div class="progress-info">
+                                <span id="progressText">Vorbereitung...</span>
+                                <span id="progressStats">0 / 0</span>
+                            </div>
+                        </div>
+
+                        <!-- Live Status Log -->
+                        <div class="send-log">
+                            <h4>📜 Versand-Log:</h4>
+                            <div id="sendLog" class="log-container"></div>
+                        </div>
+                    </div>
+
+                    <!-- Ergebnis-Zusammenfassung -->
+                    <div id="resultsContainer" class="section" style="display: none;">
+                        <h3>✅ Versand abgeschlossen</h3>
+                        <div class="results-summary">
+                            <div class="result-stats">
+                                <div class="result-stat">
+                                    <div class="stat-number" id="sentCount">0</div>
+                                    <div class="stat-label">Erfolgreich gesendet</div>
+                                </div>
+                                <div class="result-stat">
+                                    <div class="stat-number" id="errorCount">0</div>
+                                    <div class="stat-label">Fehler</div>
+                                </div>
+                                <div class="result-stat">
+                                    <div class="stat-number" id="totalTime">0s</div>
+                                    <div class="stat-label">Gesamtzeit</div>
+                                </div>
+                            </div>
+
+                            <div id="errorDetails" class="error-details" style="display: none;">
+                                <h4>❌ Fehler-Details:</h4>
+                                <div id="errorList" class="error-list"></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Empty State (initial) -->
+                    <div id="emptyState" class="empty-state">
+                        <div class="empty-state-content">
+                            <div class="empty-icon">📧</div>
+                            <h3>Keine aktive Kampagne</h3>
+                            <p>Verwenden Sie den Mail Wizard um eine neue E-Mail-Kampagne zu erstellen.</p>
+                            <button class="btn btn-primary" onclick="showMailWizard()">
+                                🧙‍♂️ Mail Wizard starten
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Status Messages -->
+                    <div id="campaignStatus"></div>
                 </main>
             </div>
 
@@ -370,6 +494,7 @@
     <script src="js/recipients.js"></script>
     <script src="js/sender.js"></script>
     <script src="js/attachments.js"></script>
+    <script src="js/campaign-sender.js"></script>
 
     <!-- External Libraries -->
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>

--- a/js/campaign-sender.js
+++ b/js/campaign-sender.js
@@ -1,0 +1,179 @@
+window.CampaignSender = (function() {
+    'use strict';
+
+    let campaignData = null;
+    let isRunning = false;
+    let sendStats = { sent: 0, errors: 0, total: 0 };
+
+    /**
+     * Lädt Kampagnen-Daten vom Mail Wizard
+     */
+    function loadCampaignData(data) {
+        campaignData = data;
+        displayCampaignData();
+        showSection('campaignDataContainer');
+        showSection('sendControlsContainer');
+        hideSection('emptyState');
+    }
+
+    /**
+     * Zeigt Kampagnen-Daten an
+     */
+    function displayCampaignData() {
+        if (!campaignData) return;
+
+        document.getElementById('campaignSubject').textContent = campaignData.subject || 'Kein Betreff';
+        document.getElementById('campaignTemplate').textContent = campaignData.template || 'Custom';
+        document.getElementById('campaignRecipientCount').textContent = campaignData.selectedRecipients.length;
+        document.getElementById('campaignAttachmentCount').textContent = campaignData.attachments?.length || 0;
+
+        // Empfänger-Liste Preview
+        const recipientsList = document.getElementById('campaignRecipientsList');
+        const recipients = campaignData.selectedRecipients.slice(0, 5); // Erste 5 zeigen
+        recipientsList.innerHTML = recipients.join(', ') +
+            (campaignData.selectedRecipients.length > 5 ? ` ... (+${campaignData.selectedRecipients.length - 5} weitere)` : '');
+    }
+
+    /**
+     * Startet Kampagne
+     */
+    function startCampaign() {
+        if (!campaignData || isRunning) return;
+
+        const testMode = document.getElementById('testModeCheckbox').checked;
+        const delay = parseInt(document.getElementById('sendDelay').value) || 2;
+
+        // Recipients filtern für Test-Modus
+        let recipients = campaignData.selectedRecipients;
+        if (testMode) {
+            recipients = recipients.slice(0, 3);
+        }
+
+        // UI für Versand vorbereiten
+        showSection('sendProgressContainer');
+        hideSection('sendControlsContainer');
+        
+        sendStats = { sent: 0, errors: 0, total: recipients.length };
+        isRunning = true;
+
+        logMessage('🚀 Kampagne gestartet...', 'info');
+        logMessage(`📧 ${recipients.length} E-Mails werden versendet`, 'info');
+        
+        // Versand starten
+        sendEmails(recipients, delay);
+    }
+
+    /**
+     * Sendet E-Mails
+     */
+    async function sendEmails(recipients, delay) {
+        const startTime = Date.now();
+
+        for (let i = 0; i < recipients.length; i++) {
+            const email = recipients[i];
+            
+            try {
+                updateProgress(i, recipients.length, `Sende an ${email}...`);
+                
+                // E-Mail senden (EmailJS)
+                const result = await sendSingleEmail(email, campaignData);
+                
+                sendStats.sent++;
+                logMessage(`✅ Erfolgreich gesendet an ${email}`, 'success');
+                
+            } catch (error) {
+                sendStats.errors++;
+                logMessage(`❌ Fehler beim Senden an ${email}: ${error.message}`, 'error');
+            }
+            
+            // Progress Update
+            updateProgress(i + 1, recipients.length);
+            
+            // Verzögerung (außer beim letzten)
+            if (i < recipients.length - 1) {
+                await new Promise(resolve => setTimeout(resolve, delay * 1000));
+            }
+        }
+
+        // Versand abgeschlossen
+        const totalTime = Math.round((Date.now() - startTime) / 1000);
+        completeCapaign(totalTime);
+    }
+
+    /**
+     * Einzelne E-Mail senden
+     */
+    async function sendSingleEmail(email, data) {
+        // EmailJS Implementation
+        const templateParams = {
+            to_email: email,
+            subject: data.subject,
+            message: data.content,
+            from_name: localStorage.getItem('fromName') || 'E-Mail Marketing Tool'
+        };
+
+        return window.emailjs.send(
+            localStorage.getItem('emailjs_service_id'),
+            localStorage.getItem('emailjs_template_id'),
+            templateParams
+        );
+    }
+
+    /**
+     * Helper Functions
+     */
+    function showSection(id) {
+        const element = document.getElementById(id);
+        if (element) element.style.display = 'block';
+    }
+
+    function hideSection(id) {
+        const element = document.getElementById(id);
+        if (element) element.style.display = 'none';
+    }
+
+    function updateProgress(current, total, message = '') {
+        const percentage = Math.round((current / total) * 100);
+        const progressBar = document.getElementById('sendProgressBar');
+        const progressText = document.getElementById('progressText');
+        const progressStats = document.getElementById('progressStats');
+
+        if (progressBar) progressBar.style.width = percentage + '%';
+        if (progressText) progressText.textContent = message || `Versendet: ${current} von ${total}`;
+        if (progressStats) progressStats.textContent = `${current} / ${total}`;
+    }
+
+    function logMessage(message, type = 'info') {
+        const logContainer = document.getElementById('sendLog');
+        if (!logContainer) return;
+
+        const timestamp = new Date().toLocaleTimeString();
+        const logEntry = document.createElement('div');
+        logEntry.className = `log-entry ${type}`;
+        logEntry.textContent = `[${timestamp}] ${message}`;
+        
+        logContainer.appendChild(logEntry);
+        logContainer.scrollTop = logContainer.scrollHeight;
+    }
+
+    function completeCapaign(totalTime) {
+        isRunning = false;
+        
+        // Results anzeigen
+        showSection('resultsContainer');
+        document.getElementById('sentCount').textContent = sendStats.sent;
+        document.getElementById('errorCount').textContent = sendStats.errors;
+        document.getElementById('totalTime').textContent = totalTime + 's';
+        
+        // "Neue Kampagne" Button zeigen
+        document.getElementById('newCampaignBtn').style.display = 'inline-block';
+        
+        logMessage(`🏁 Kampagne abgeschlossen! ${sendStats.sent} gesendet, ${sendStats.errors} Fehler`, 'info');
+    }
+
+    return {
+        loadCampaignData,
+        startCampaign,
+        showPreview: () => alert('Preview-Funktion folgt später')
+    };
+})();

--- a/js/mail-wizard.js
+++ b/js/mail-wizard.js
@@ -1102,40 +1102,18 @@ window.MailWizard = (function() {
      * Überträgt Wizard-Daten zum Haupt-Editor
      */
     function transferToMainEditor() {
-        // Subject
-        const subjectInput = document.getElementById('subject');
-        if (subjectInput) {
-            subjectInput.value = wizardData.subject;
-        }
-        
-        // HTML Content
-        const htmlContent = document.getElementById('htmlContent');
-        if (htmlContent) {
-            htmlContent.value = wizardData.content;
-        }
-        
-        // Template Name für Speicherung
-        const templateName = document.getElementById('templateName');
-        if (templateName && !templateName.value.trim()) {
-            const timestamp = new Date().toLocaleDateString('de-DE');
-            templateName.value = `Wizard Mail ${timestamp}`;
-        }
-        
-        // Preview aktualisieren
-        if (window.Templates) {
-            Templates.updatePreview();
-            
-            // Simple Editor neu parsen
-            setTimeout(() => {
-                if (Templates.getCurrentMode() === 'simple') {
-                    Templates.parseTemplate();
-                }
-            }, 100);
-        }
-        
-        // Send-Tab Empfänger-Liste aktualisieren
-        if (window.Sender) {
-            Sender.updateRecipientsList();
+        // Daten sammeln
+        const campaignData = {
+            subject: wizardData.subject,
+            content: wizardData.content,
+            template: wizardData.template,
+            selectedRecipients: wizardData.selectedRecipients,
+            attachments: wizardData.attachments || []
+        };
+
+        // An CampaignSender übergeben
+        if (window.CampaignSender) {
+            CampaignSender.loadCampaignData(campaignData);
         }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -2137,6 +2137,232 @@ small {
     color: #374151;
 }
 
+/* === CAMPAIGN SUMMARY === */
+.campaign-summary {
+    background: #f8f9fa;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    padding: 24px;
+    margin-bottom: 30px;
+}
+
+.campaign-info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.campaign-info-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 12px;
+    background: white;
+    border-radius: 8px;
+    border: 1px solid #e9ecef;
+}
+
+.campaign-info-item label {
+    font-weight: 500;
+    color: #495057;
+}
+
+.campaign-info-item span {
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.campaign-recipients-preview {
+    border-top: 1px solid #e9ecef;
+    padding-top: 20px;
+}
+
+.recipient-preview-list {
+    max-height: 120px;
+    overflow-y: auto;
+    background: white;
+    border: 1px solid #e9ecef;
+    border-radius: 6px;
+    padding: 12px;
+    font-size: 14px;
+}
+
+/* === SEND CONTROLS === */
+.send-controls {
+    background: #f8f9fa;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    padding: 24px;
+    margin-bottom: 30px;
+}
+
+.send-options {
+    margin-bottom: 24px;
+}
+
+.send-actions {
+    display: flex;
+    gap: 15px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.btn-large {
+    padding: 15px 30px;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+/* === PROGRESS === */
+.progress-container {
+    background: #f8f9fa;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    padding: 24px;
+    margin-bottom: 30px;
+}
+
+.progress-bar-container {
+    width: 100%;
+    height: 30px;
+    background: #e9ecef;
+    border-radius: 15px;
+    overflow: hidden;
+    margin-bottom: 16px;
+}
+
+.progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, #4a90e2, #27ae60);
+    border-radius: 15px;
+    transition: width 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 600;
+}
+
+.progress-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 500;
+}
+
+/* === SEND LOG === */
+.send-log {
+    margin-top: 24px;
+}
+
+.log-container {
+    background: #2c3e50;
+    color: #ecf0f1;
+    border-radius: 8px;
+    padding: 16px;
+    font-family: 'Courier New', monospace;
+    font-size: 13px;
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px solid #34495e;
+}
+
+.log-entry {
+    margin-bottom: 4px;
+    padding: 2px 0;
+}
+
+.log-entry.success {
+    color: #2ecc71;
+}
+
+.log-entry.error {
+    color: #e74c3c;
+}
+
+.log-entry.info {
+    color: #3498db;
+}
+
+/* === RESULTS === */
+.results-summary {
+    background: #f8f9fa;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    padding: 24px;
+}
+
+.result-stats {
+    display: flex;
+    gap: 30px;
+    justify-content: center;
+    margin-bottom: 24px;
+}
+
+.result-stat {
+    text-align: center;
+    padding: 20px;
+    background: white;
+    border-radius: 12px;
+    border: 1px solid #e9ecef;
+    min-width: 120px;
+}
+
+.result-stat .stat-number {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: #4a90e2;
+    margin-bottom: 8px;
+}
+
+.result-stat .stat-label {
+    font-size: 14px;
+    color: #6c757d;
+    font-weight: 500;
+}
+
+.error-details {
+    border-top: 1px solid #e9ecef;
+    padding-top: 20px;
+}
+
+.error-list {
+    background: #fff5f5;
+    border: 1px solid #fed7d7;
+    border-radius: 6px;
+    padding: 12px;
+    max-height: 150px;
+    overflow-y: auto;
+}
+
+/* === EMPTY STATE === */
+.empty-state {
+    text-align: center;
+    padding: 80px 20px;
+}
+
+.empty-state-content {
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+.empty-icon {
+    font-size: 72px;
+    margin-bottom: 24px;
+    opacity: 0.6;
+}
+
+.empty-state h3 {
+    color: #2c3e50;
+    margin-bottom: 12px;
+}
+
+.empty-state p {
+    color: #6c757d;
+    margin-bottom: 24px;
+    line-height: 1.6;
+}
+
 /* Responsive Footer */
 @media (max-width: 768px) {
     .footer-content {


### PR DESCRIPTION
## Summary
- implement full Mail Wizard tab for sending campaigns
- add CampaignSender module
- wire up wizard to CampaignSender
- style campaign sending pages

## Testing
- `node backend/test-auth.js` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68590efffbb48323a3b60a6013bb6807