### PR TITLE
Add loading screen with animated orb

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,40 @@
     <link rel="stylesheet" href="styles.css">
     </head>
 <body>
+    <div id="loadingScreen" class="loading-screen">
+        <div class="loading-container">
+            <!-- CSS-basierter Orb (WebGL-Alternative) -->
+            <div class="css-orb">
+                <div class="orb-core"></div>
+                <div class="orb-ring ring-1"></div>
+                <div class="orb-ring ring-2"></div>
+                <div class="orb-ring ring-3"></div>
+                <div class="orb-glow"></div>
+            </div>
+
+            <!-- Loading Text & Progress -->
+            <div class="loading-content">
+                <h2 class="loading-title">🐦 pigeon.run</h2>
+                <p class="loading-subtitle">E-Mail Marketing Tool wird geladen...</p>
+
+                <!-- Animated Dots -->
+                <div class="loading-dots">
+                    <span class="dot"></span>
+                    <span class="dot"></span>
+                    <span class="dot"></span>
+                </div>
+
+                <!-- Optional: Progress Bar -->
+                <div class="loading-progress">
+                    <div class="progress-bar">
+                        <div class="progress-fill" id="loadingProgress"></div>
+                    </div>
+                    <span class="progress-text" id="loadingText">Lade Komponenten...</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="container">
         <!-- Simple Header -->
         <header class="header">
@@ -506,6 +540,102 @@
     <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"></script>
     <script>
     console.log('EmailJS loaded:', window.emailjs ? 'YES' : 'NO');
+    </script>
+
+    <script>
+        // Loading Screen Management
+        window.LoadingScreen = (function() {
+            let progressValue = 0;
+            let loadingTexts = [
+                'Lade Komponenten...',
+                'Initialisiere Module...',
+                'Vorbereitung der Benutzeroberfläche...',
+                'Fast fertig...'
+            ];
+            let currentTextIndex = 0;
+
+            function updateProgress(percent, customText = null) {
+                const progressBar = document.getElementById('loadingProgress');
+                const progressText = document.getElementById('loadingText');
+
+                if (progressBar) {
+                    progressBar.style.width = percent + '%';
+                }
+
+                if (progressText && customText) {
+                    progressText.textContent = customText;
+                } else if (progressText && percent > progressValue) {
+                    if (percent > 25 && currentTextIndex < 1) {
+                        currentTextIndex = 1;
+                        progressText.textContent = loadingTexts[currentTextIndex];
+                    } else if (percent > 50 && currentTextIndex < 2) {
+                        currentTextIndex = 2;
+                        progressText.textContent = loadingTexts[currentTextIndex];
+                    } else if (percent > 80 && currentTextIndex < 3) {
+                        currentTextIndex = 3;
+                        progressText.textContent = loadingTexts[currentTextIndex];
+                    }
+                }
+
+                progressValue = percent;
+            }
+
+            function hide() {
+                const loadingScreen = document.getElementById('loadingScreen');
+                if (loadingScreen) {
+                    updateProgress(100, 'Fertig!');
+                    setTimeout(() => {
+                        loadingScreen.classList.add('hidden');
+                        setTimeout(() => {
+                            loadingScreen.remove();
+                        }, 500);
+                    }, 200);
+                }
+            }
+
+            function simulateProgress() {
+                let progress = 0;
+                const interval = setInterval(() => {
+                    progress += Math.random() * 15;
+                    if (progress >= 90) {
+                        clearInterval(interval);
+                        progress = 90;
+                    }
+                    updateProgress(Math.min(progress, 90));
+                }, 200);
+            }
+
+            return {
+                updateProgress,
+                hide,
+                simulateProgress
+            };
+        })();
+
+        // Start simulated progress immediately
+        LoadingScreen.simulateProgress();
+
+        // Hide loading screen when app is ready
+        document.addEventListener('DOMContentLoaded', function() {
+            function checkAppReady() {
+                const isReady = window.App &&
+                               window.Templates &&
+                               window.Recipients &&
+                               document.querySelector('.tabs');
+
+                if (isReady) {
+                    LoadingScreen.hide();
+                } else {
+                    setTimeout(checkAppReady, 100);
+                }
+            }
+
+            setTimeout(checkAppReady, 500);
+        });
+
+        setTimeout(() => {
+            LoadingScreen.hide();
+        }, 10000);
     </script>
     </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -48,7 +48,14 @@ window.App = (function() {
             // 6. Zeige initiale UI
             showInitialInterface();
 
+            // App fertig geladen
             isInitialized = true;
+
+            // Loading Screen verstecken
+            if (window.LoadingScreen) {
+                LoadingScreen.hide();
+            }
+
             console.log('✅ App initialization complete');
 
         } catch (error) {

--- a/styles.css
+++ b/styles.css
@@ -2460,3 +2460,293 @@ small {
     }
     */
 }
+
+/* === LOADING SCREEN === */
+.loading-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+    opacity: 1;
+    transition: opacity 0.5s ease, visibility 0.5s ease;
+}
+
+.loading-screen.hidden {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.loading-container {
+    text-align: center;
+    color: white;
+    animation: fadeInUp 0.8s ease;
+}
+
+/* === CSS ORB (WebGL-Alternative) === */
+.css-orb {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    margin: 0 auto 40px;
+    animation: orbFloat 6s ease-in-out infinite;
+}
+
+.orb-core {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 80px;
+    height: 80px;
+    background: radial-gradient(circle at 30% 30%, 
+        rgba(255, 255, 255, 0.8), 
+        rgba(102, 126, 234, 0.9), 
+        rgba(29, 78, 216, 1));
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    animation: orbPulse 3s ease-in-out infinite;
+    box-shadow: 
+        0 0 30px rgba(102, 126, 234, 0.6),
+        inset 0 0 20px rgba(255, 255, 255, 0.2);
+}
+
+.orb-ring {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    animation-duration: 4s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+}
+
+.ring-1 {
+    width: 120px;
+    height: 120px;
+    animation-name: orbRotate;
+    border-top-color: rgba(102, 126, 234, 0.8);
+}
+
+.ring-2 {
+    width: 160px;
+    height: 160px;
+    animation-name: orbRotateReverse;
+    animation-duration: 6s;
+    border-right-color: rgba(118, 75, 162, 0.6);
+}
+
+.ring-3 {
+    width: 200px;
+    height: 200px;
+    animation-name: orbRotate;
+    animation-duration: 8s;
+    border-left-color: rgba(102, 126, 234, 0.4);
+}
+
+.orb-glow {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 240px;
+    height: 240px;
+    background: radial-gradient(circle, 
+        rgba(102, 126, 234, 0.3) 0%, 
+        rgba(102, 126, 234, 0.1) 50%, 
+        transparent 70%);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    animation: orbGlow 4s ease-in-out infinite;
+}
+
+/* === ORB ANIMATIONS === */
+@keyframes orbFloat {
+    0%, 100% { 
+        transform: translateY(0px); 
+    }
+    50% { 
+        transform: translateY(-20px); 
+    }
+}
+
+@keyframes orbPulse {
+    0%, 100% { 
+        transform: translate(-50%, -50%) scale(1); 
+        box-shadow: 0 0 30px rgba(102, 126, 234, 0.6);
+    }
+    50% { 
+        transform: translate(-50%, -50%) scale(1.1); 
+        box-shadow: 0 0 50px rgba(102, 126, 234, 0.8);
+    }
+}
+
+@keyframes orbRotate {
+    from { transform: translate(-50%, -50%) rotate(0deg); }
+    to { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+@keyframes orbRotateReverse {
+    from { transform: translate(-50%, -50%) rotate(360deg); }
+    to { transform: translate(-50%, -50%) rotate(0deg); }
+}
+
+@keyframes orbGlow {
+    0%, 100% { 
+        opacity: 0.5; 
+        transform: translate(-50%, -50%) scale(1); 
+    }
+    50% { 
+        opacity: 0.8; 
+        transform: translate(-50%, -50%) scale(1.1); 
+    }
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* === LOADING CONTENT === */
+.loading-content {
+    animation: fadeInUp 1s ease 0.3s both;
+}
+
+.loading-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin: 0 0 8px 0;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.loading-subtitle {
+    font-size: 1.1rem;
+    margin: 0 0 30px 0;
+    opacity: 0.9;
+    font-weight: 400;
+}
+
+/* === ANIMATED DOTS === */
+.loading-dots {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 30px;
+}
+
+.dot {
+    width: 12px;
+    height: 12px;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 50%;
+    animation: dotBounce 1.4s ease-in-out infinite both;
+}
+
+.dot:nth-child(1) { animation-delay: -0.32s; }
+.dot:nth-child(2) { animation-delay: -0.16s; }
+.dot:nth-child(3) { animation-delay: 0s; }
+
+@keyframes dotBounce {
+    0%, 80%, 100% {
+        transform: scale(0.8);
+        opacity: 0.5;
+    }
+    40% {
+        transform: scale(1.2);
+        opacity: 1;
+    }
+}
+
+/* === PROGRESS BAR === */
+.loading-progress {
+    max-width: 300px;
+    margin: 0 auto;
+}
+
+.progress-bar {
+    width: 100%;
+    height: 4px;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-bottom: 12px;
+}
+
+.progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, 
+        rgba(255, 255, 255, 0.8) 0%, 
+        rgba(255, 255, 255, 1) 50%, 
+        rgba(255, 255, 255, 0.8) 100%);
+    border-radius: 2px;
+    width: 0%;
+    transition: width 0.3s ease;
+    animation: progressShimmer 2s linear infinite;
+}
+
+.progress-text {
+    font-size: 0.9rem;
+    opacity: 0.8;
+    font-weight: 500;
+}
+
+@keyframes progressShimmer {
+    0% { background-position: -200px 0; }
+    100% { background-position: 200px 0; }
+}
+
+/* === RESPONSIVE === */
+@media (max-width: 768px) {
+    .css-orb {
+        width: 150px;
+        height: 150px;
+        margin-bottom: 30px;
+    }
+    
+    .orb-core {
+        width: 60px;
+        height: 60px;
+    }
+    
+    .ring-1 { width: 90px; height: 90px; }
+    .ring-2 { width: 120px; height: 120px; }
+    .ring-3 { width: 150px; height: 150px; }
+    .orb-glow { width: 180px; height: 180px; }
+    
+    .loading-title {
+        font-size: 2rem;
+    }
+    
+    .loading-subtitle {
+        font-size: 1rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .css-orb {
+        width: 120px;
+        height: 120px;
+    }
+    
+    .orb-core {
+        width: 50px;
+        height: 50px;
+    }
+    
+    .ring-1 { width: 70px; height: 70px; }
+    .ring-2 { width: 90px; height: 90px; }
+    .ring-3 { width: 120px; height: 120px; }
+    .orb-glow { width: 150px; height: 150px; }
+}


### PR DESCRIPTION
## Summary
- add professional loading overlay with CSS orb animation
- manage loading progress and hide overlay when app is ready
- hide loading screen from app init

## Testing
- `npm install` (backend)
- `PORT=8080 node index.js & node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_685912bd3be48323a2bab05e36caf558