### PR TITLE
Fix wizard modal height on desktop

### DIFF
--- a/js/mail-wizard.js
+++ b/js/mail-wizard.js
@@ -1323,3 +1323,49 @@ function generateWizardButtons() {
         getTemplateLabel
     };
 })();
+
+// DEBUGGING TOOL: Inspect modal dimensions in the browser console
+function debugModalLayout() {
+    const modal = document.querySelector('.wizard-modal');
+    const content = document.querySelector('.wizard-content');
+    const buttons = document.querySelector('.wizard-buttons');
+
+    console.log('=== MODAL LAYOUT DEBUG ===');
+    console.log('Viewport height:', window.innerHeight);
+    console.log('Viewport width:', window.innerWidth);
+
+    if (modal) {
+        const rect = modal.getBoundingClientRect();
+        console.log('Modal dimensions:', {
+            width: rect.width,
+            height: rect.height,
+            top: rect.top,
+            bottom: rect.bottom,
+            isInViewport: rect.bottom <= window.innerHeight
+        });
+    }
+
+    if (content) {
+        const rect = content.getBoundingClientRect();
+        console.log('Content dimensions:', {
+            height: rect.height,
+            maxHeight: getComputedStyle(content).maxHeight,
+            overflow: getComputedStyle(content).overflow
+        });
+    }
+
+    if (buttons) {
+        const rect = buttons.getBoundingClientRect();
+        console.log('Buttons dimensions:', {
+            height: rect.height,
+            top: rect.top,
+            bottom: rect.bottom,
+            isVisible: rect.top < window.innerHeight && rect.bottom > 0,
+            display: getComputedStyle(buttons).display,
+            position: getComputedStyle(buttons).position
+        });
+    }
+
+    console.log('=== END MODAL DEBUG ===');
+}
+

--- a/styles.css
+++ b/styles.css
@@ -2767,3 +2767,129 @@ small {
     .ring-3 { width: 120px; height: 120px; }
     .orb-glow { width: 150px; height: 150px; }
 }
+
+/* === MODAL DESKTOP BUTTON VISIBILITY FIX === */
+/* In styles.css - Modal Desktop Height Fix: */
+.wizard-modal,
+.mail-wizard-container {
+    background: white;
+    border-radius: 15px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+    width: 90%;
+    max-width: 900px;
+    max-height: 80vh !important;
+    height: auto !important;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Ensure wizard content scrolls but doesn't hide buttons */
+.wizard-modal .wizard-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px;
+    max-height: calc(80vh - 200px) !important;
+}
+
+/* Ensure wizard buttons stay visible */
+.wizard-modal .wizard-buttons {
+    flex-shrink: 0 !important;
+    position: relative !important;
+    bottom: 0 !important;
+    background: #f8f9fa;
+    border-top: 1px solid #e9ecef;
+    padding: 20px 30px;
+    display: flex !important;
+    justify-content: space-between;
+    z-index: 1000 !important;
+}
+
+/* Desktop-specific Media Query Fixes */
+@media (min-width: 769px) {
+    /* Desktop: Modal kleiner und zentriert */
+    .wizard-modal,
+    .mail-wizard-container {
+        width: 85% !important;
+        max-width: 800px !important;
+        max-height: 75vh !important;
+    }
+
+    /* Desktop: Button Container explizit sichtbar */
+    .wizard-buttons {
+        display: flex !important;
+        position: relative !important;
+        bottom: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+        background: #f8f9fa !important;
+        border-top: 2px solid #e9ecef !important;
+        padding: 24px 32px !important;
+        margin: 0 !important;
+        z-index: 1001 !important;
+        min-height: 80px !important;
+    }
+
+    /* Desktop: Content Area begrenzen */
+    .wizard-content {
+        max-height: calc(75vh - 220px) !important;
+        overflow-y: auto !important;
+        padding: 24px 32px !important;
+    }
+
+    /* Desktop: Buttons explizit sichtbar */
+    .wizard-buttons button {
+        display: inline-block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        position: relative !important;
+        z-index: 1002 !important;
+    }
+}
+
+/* Flexbox Layout für Modal sicherstellen */
+.wizard-modal {
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: space-between !important;
+}
+
+.wizard-header {
+    flex-shrink: 0 !important;
+    order: 1 !important;
+}
+
+.wizard-content {
+    flex: 1 1 auto !important;
+    order: 2 !important;
+    overflow-y: auto !important;
+    min-height: 0 !important;
+}
+
+.wizard-buttons {
+    flex-shrink: 0 !important;
+    order: 3 !important;
+    margin-top: auto !important;
+}
+
+/* Emergency Override */
+@media (min-width: 768px) and (min-height: 600px) {
+    .wizard-overlay {
+        padding: 20px !important;
+        box-sizing: border-box !important;
+    }
+
+    .wizard-modal {
+        max-height: calc(100vh - 40px) !important;
+        height: auto !important;
+        overflow: visible !important;
+    }
+
+    .wizard-buttons {
+        position: sticky !important;
+        bottom: 0 !important;
+        background: #f8f9fa !important;
+        z-index: 9999 !important;
+        box-shadow: 0 -2px 10px rgba(0,0,0,0.1) !important;
+    }
+}


### PR DESCRIPTION
## Summary
- adjust modal styles to avoid overflow on desktop
- add debug function for wizard modal layout

## Testing
- `npm test` *(fails: Missing script)*
- `node ../generate-version.js` *(fails: ENOENT js/version.js)*


------
https://chatgpt.com/codex/tasks/task_e_68592aaaf728832387d120978ed48f4e