### PR TITLE
Fix EmailJS template ID sync

### DIFF
--- a/js/campaign-sender.js
+++ b/js/campaign-sender.js
@@ -105,19 +105,25 @@ window.CampaignSender = (function() {
      * Einzelne E-Mail senden
      */
     async function sendSingleEmail(email, data) {
+        // Einheitliche Config-Auflösung
+        const serviceId = localStorage.getItem('emailjs_service_id');
+        const templateId = localStorage.getItem('emailjs_template_id');
+        const fromName = localStorage.getItem('fromName') || 'E-Mail Marketing Tool';
+
+        if (!serviceId || !templateId) {
+            throw new Error(`EmailJS Konfiguration fehlt - Service: ${serviceId}, Template: ${templateId}`);
+        }
+
         const templateParams = {
-            to_email: email,
             subject: data.subject,
             message: data.content,
-            from_name: localStorage.getItem('fromName') || 'E-Mail Marketing Tool'
+            to_email: email,
+            name: fromName,
+            email: email
         };
 
         try {
-            const response = await window.emailjs.send(
-                localStorage.getItem('emailjs_service_id'),
-                localStorage.getItem('emailjs_template_id'),
-                templateParams
-            );
+            const response = await window.emailjs.send(serviceId, templateId, templateParams);
 
             if (response.status !== 200) {
                 throw { status: response.status, text: response.text };

--- a/js/config.js
+++ b/js/config.js
@@ -108,18 +108,25 @@ window.Config = (function() {
             // Config speichern
             currentConfig = { ...currentConfig, ...config };
             const success = Utils.saveToStorage(STORAGE_KEYS.EMAIL_CONFIG, currentConfig);
-            
+
             if (success) {
+                // CRITICAL FIX: Legacy-Kompatibilität sicherstellen
+                localStorage.setItem('emailjs_service_id', currentConfig.serviceId);
+                localStorage.setItem('emailjs_template_id', currentConfig.templateId);
+                localStorage.setItem('emailjs_user_id', currentConfig.userId);
+                localStorage.setItem('fromName', currentConfig.fromName);
+                localStorage.setItem('emailjs_configured', 'true');
+
                 // EmailJS re-initialisieren
                 if (currentConfig.userId && window.emailjs) {
                     emailjs.init(currentConfig.userId);
                 }
-                
+
                 Utils.showStatus('configStatus', 'Konfiguration gespeichert!', 'success');
-                
+
                 // Setup-Prompt verstecken falls sichtbar
                 Utils.toggleElement('setupPrompt', false);
-                
+
                 return true;
             } else {
                 Utils.showStatus('configStatus', 'Fehler beim Speichern!', 'error');

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -488,16 +488,14 @@ window.Wizard = (function() {
             setupCompleted: true
         };
 
-        // Config speichern
+        // Config über offizielle API speichern (macht auch localStorage-Sync)
         const success = Config.saveConfig(config);
-        
+
         if (success) {
-            // WICHTIG: Setup-Status für Landing Page setzen
+            // Zusätzliche Setup-Status-Marker für Landing Page
             localStorage.setItem('emailjs_configured', 'true');
-            localStorage.setItem('emailjs_service_id', config.serviceId);
-            localStorage.setItem('fromName', config.fromName);
-            
-            // Hauptkonfiguration auch aktualisieren
+
+            // Hauptkonfiguration UI auch aktualisieren
             updateMainConfigUI(config);
             console.log('Wizard config saved successfully');
         }


### PR DESCRIPTION
## Summary
- sync config to legacy localStorage in `saveConfig`
- update wizard to rely on `Config.saveConfig`
- robust config resolution when sending via `sender.js`
- unify template params in `campaign-sender.js`

## Testing
- `node backend/test-auth.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6859397798248323b0a13854cd9d8d85