### PR TITLE
Fix personalization placeholders before sending

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -57,14 +57,21 @@ window.Utils = (function() {
      * @returns {string} Generierter Name
      */
     function getNameFromEmail(email) {
-        if (!email || !isValidEmail(email)) return 'Unbekannt';
-        
-        const localPart = email.split('@')[0];
-        const nameParts = localPart.split(/[._-]+/);
-        
-        return nameParts
-            .map(part => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
-            .join(' ');
+        if (!email || !email.includes('@')) return 'Unbekannt';
+
+        try {
+            const localPart = email.split('@')[0];
+            const nameParts = localPart.split(/[._-]+/);
+
+            const processedParts = nameParts.slice(0, 2).map(part => {
+                return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+            });
+
+            return processedParts.join(' ') || 'Unbekannt';
+        } catch (error) {
+            console.error('Error generating name from email:', error);
+            return 'Unbekannt';
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- personalize template placeholders with rich fallbacks
- add extensive debug info when sending one email
- improve current template detection
- better name generation from email address

## Testing
- `node backend/test-auth.js` *(fails: Cannot connect to local server)*

------
https://chatgpt.com/codex/tasks/task_e_685942f5bd088323b9df7eaca6123259