### PR TITLE
Implement campaign save/send flow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-}
+} 
 
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
@@ -485,7 +485,168 @@ small {
     .manual-input-form {
         grid-template-columns: 1fr;
         gap: 15px;
-    }
+} 
+}
+
+/* Campaign Overview Styles */
+.campaign-overview-content {
+    padding: 20px;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
+.campaign-info-section,
+.campaign-recipients-section,
+.campaign-preview-section,
+.campaign-send-section,
+.campaign-progress-section {
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid #e9ecef;
+}
+
+.campaign-info-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+    margin-top: 15px;
+}
+
+.info-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background: #f8f9fa;
+    border-radius: 6px;
+}
+
+.status-badge {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.status-badge.draft {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.recipients-list {
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px solid #e9ecef;
+    border-radius: 6px;
+    padding: 10px;
+}
+
+.recipient-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 6px 0;
+    border-bottom: 1px solid #f1f3f4;
+}
+
+.email-preview-container {
+    border: 1px solid #e9ecef;
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.email-preview-header {
+    background: #f8f9fa;
+    padding: 12px 16px;
+    border-bottom: 1px solid #e9ecef;
+    font-size: 14px;
+}
+
+.email-preview-body {
+    padding: 16px;
+    background: white;
+    font-family: Arial, sans-serif;
+    line-height: 1.6;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.send-options {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.send-actions {
+    display: flex;
+    gap: 15px;
+}
+
+.btn-large {
+    padding: 12px 24px;
+    font-size: 16px;
+    font-weight: 500;
+}
+
+/* Progress Styles */
+.campaign-progress-section .progress-bar-container {
+    margin-bottom: 20px;
+}
+
+.campaign-progress-section .progress-bar {
+    width: 100%;
+    height: 20px;
+    background: #e9ecef;
+    border-radius: 10px;
+    overflow: hidden;
+    margin-bottom: 10px;
+}
+
+.campaign-progress-section .progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #28a745, #20c997);
+    transition: width 0.3s ease;
+}
+
+.campaign-progress-section .progress-text {
+    display: flex;
+    justify-content: space-between;
+    font-size: 14px;
+    color: #6c757d;
+}
+
+.log-container {
+    max-height: 200px;
+    overflow-y: auto;
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 6px;
+    padding: 10px;
+    font-family: monospace;
+    font-size: 13px;
+}
+
+.log-entry {
+    padding: 2px 0;
+    border-bottom: 1px solid #e9ecef;
+}
+
+.log-entry:last-child {
+    border-bottom: none;
+}
+
+.log-time {
+    color: #6c757d;
+    margin-right: 8px;
+}
+
+.log-error {
+    color: #dc3545;
+}
+
+.progress-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 15px;
 }
 
 /* === RECIPIENT CONTROLS === */


### PR DESCRIPTION
## Summary
- finalize campaign wizard by saving campaign draft and showing overview
- add campaign sending with personalized emails and progress logging
- style campaign overview UI

## Testing
- `node backend/test-auth.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_685968f01ec88323accad4458a469f2d