### PR TITLE
Implement campaigns tab and wizard simplification

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
             <button class="tab" onclick="App.showTab('templates')">Templates</button>
             <button class="tab" onclick="App.showTab('recipients')">Empfänger</button>
             <button class="tab" onclick="App.showTab('mailwizard')">Mail Wizard</button>
+            <button class="tab" onclick="App.showTab('campaigns')">Kampagnen</button>
             <button class="tab" onclick="App.showTab('history')">Verlauf</button>
         </nav>
 
@@ -367,6 +368,39 @@
                 </main>
             </div>
 
+            <!-- Campaigns Tab -->
+            <div id="campaigns" class="tab-content">
+                <main class="main-card">
+                    <h2>📋 Kampagnen-Verwaltung</h2>
+
+                    <!-- Quick Actions -->
+                    <div class="campaign-quick-actions">
+                        <button class="btn btn-primary" onclick="showMailWizard()">
+                            ➕ Neue Kampagne erstellen
+                        </button>
+                        <button class="btn btn-secondary" onclick="Campaigns.refreshList()">
+                            🔄 Liste aktualisieren
+                        </button>
+                    </div>
+
+                    <!-- Kampagnen-Liste -->
+                    <div class="campaigns-section">
+                        <h3>📂 Gespeicherte Kampagnen</h3>
+                        <div id="campaignsList" class="campaigns-list">
+                            <!-- Wird dynamisch gefüllt -->
+                        </div>
+                    </div>
+
+                    <!-- Aktive Kampagne -->
+                    <div id="activeCampaignSection" class="active-campaign-section" style="display: none;">
+                        <h3>🚀 Aktive Kampagne</h3>
+                        <div id="activeCampaignContainer">
+                            <!-- Aktiver Versand wird hier angezeigt -->
+                        </div>
+                    </div>
+                </main>
+            </div>
+
             <!-- History Tab -->
             <div id="history" class="tab-content">
                 <main class="main-card">
@@ -619,6 +653,7 @@
     <script src="js/recipients.js"></script>
     <script src="js/sender.js"></script>
     <script src="js/attachments.js"></script>
+    <script src="js/campaigns.js"></script>
     <script src="js/campaign-sender.js"></script>
 
     <!-- External Libraries -->

--- a/js/app.js
+++ b/js/app.js
@@ -104,6 +104,13 @@ window.App = (function() {
             console.log('✓ MailWizard module loaded');
         }
 
+        // Campaigns-Modul initialisieren
+        if (window.Campaigns) {
+            Campaigns.init();
+            modules.campaigns = window.Campaigns;
+            console.log('✓ Campaigns module loaded');
+        }
+
         // Weitere Module werden hier initialisiert wenn verfügbar
         const moduleList = ['Wizard', 'Templates', 'Recipients', 'Sender', 'Attachments'];
                 

--- a/js/campaigns.js
+++ b/js/campaigns.js
@@ -1,0 +1,377 @@
+/**
+ * E-Mail Marketing Tool - Campaigns Management
+ * Verwaltet gespeicherte Kampagnen und deren Versand
+ */
+
+window.Campaigns = (function() {
+    'use strict';
+
+    // ===== CAMPAIGNS STATE =====
+    let campaigns = [];
+    let activeCampaign = null;
+
+    // ===== INITIALIZATION =====
+
+    function init() {
+        loadCampaigns();
+        updateCampaignsList();
+        
+        console.log('✓ Campaigns module initialized');
+    }
+
+    // ===== CAMPAIGN MANAGEMENT =====
+
+    /**
+     * Lädt alle gespeicherten Kampagnen
+     */
+    function loadCampaigns() {
+        try {
+            campaigns = JSON.parse(localStorage.getItem('campaignDrafts') || '[]');
+            console.log(`Loaded ${campaigns.length} campaigns`);
+        } catch (error) {
+            console.error('Error loading campaigns:', error);
+            campaigns = [];
+        }
+    }
+
+    /**
+     * Aktualisiert Kampagnen-Liste
+     */
+    function updateCampaignsList() {
+        const container = document.getElementById('campaignsList');
+        if (!container) return;
+
+        if (campaigns.length === 0) {
+            container.innerHTML = `
+                <div class="empty-state">
+                    <div class="empty-icon">📭</div>
+                    <h3>Keine Kampagnen vorhanden</h3>
+                    <p>Erstelle deine erste Kampagne mit dem Mail Wizard</p>
+                    <button class="btn btn-primary" onclick="showMailWizard()">
+                        ➕ Erste Kampagne erstellen
+                    </button>
+                </div>
+            `;
+            return;
+        }
+
+        // Kampagnen nach Datum sortieren (neueste zuerst)
+        const sortedCampaigns = [...campaigns].sort((a, b) => 
+            new Date(b.createdAt) - new Date(a.createdAt)
+        );
+
+        const campaignsHTML = sortedCampaigns.map(campaign => `
+            <div class="campaign-card" data-id="${campaign.id}">
+                <div class="campaign-header">
+                    <h4 class="campaign-title">${Utils.escapeHtml(campaign.name)}</h4>
+                    <div class="campaign-status">
+                        <span class="status-badge ${campaign.status}">${getStatusLabel(campaign.status)}</span>
+                    </div>
+                </div>
+                
+                <div class="campaign-details">
+                    <div class="campaign-info">
+                        <span class="info-item">📧 ${campaign.stats.total} Empfänger</span>
+                        <span class="info-item">📅 ${new Date(campaign.createdAt).toLocaleDateString('de-DE')}</span>
+                        <span class="info-item">📊 ${campaign.stats.sent}/${campaign.stats.total} gesendet</span>
+                    </div>
+                    
+                    <div class="campaign-subject">
+                        <strong>Betreff:</strong> ${Utils.escapeHtml(campaign.subject)}
+                    </div>
+                </div>
+                
+                <div class="campaign-actions">
+                    <button class="btn btn-info btn-sm" onclick="Campaigns.previewCampaign('${campaign.id}')">
+                        👁️ Vorschau
+                    </button>
+                    <button class="btn btn-primary btn-sm" onclick="Campaigns.editCampaign('${campaign.id}')">
+                        ✏️ Bearbeiten
+                    </button>
+                    ${campaign.status === 'draft' ? `
+                        <button class="btn btn-success btn-sm" onclick="Campaigns.startCampaign('${campaign.id}')">
+                            🚀 Senden
+                        </button>
+                    ` : ''}
+                    <button class="btn btn-danger btn-sm" onclick="Campaigns.deleteCampaign('${campaign.id}')">
+                        🗑️ Löschen
+                    </button>
+                </div>
+            </div>
+        `).join('');
+
+        container.innerHTML = campaignsHTML;
+    }
+
+    /**
+     * Startet Kampagnen-Versand
+     */
+    function startCampaign(campaignId) {
+        const campaign = campaigns.find(c => c.id === campaignId);
+        if (!campaign) {
+            alert('Kampagne nicht gefunden');
+            return;
+        }
+
+        // Aktive Kampagne setzen
+        activeCampaign = campaign;
+        
+        // UI für aktive Kampagne anzeigen
+        showActiveCampaignUI(campaign);
+        
+        console.log('Starting campaign:', campaignId);
+    }
+
+    /**
+     * Zeigt UI für aktive Kampagne
+     */
+    function showActiveCampaignUI(campaign) {
+        const section = document.getElementById('activeCampaignSection');
+        const container = document.getElementById('activeCampaignContainer');
+        
+        if (!section || !container) return;
+
+        // UI-Container erstellen (DIESELBE wie im Mail Wizard)
+        container.innerHTML = `
+            <div class="active-campaign-card">
+                <div class="campaign-header">
+                    <h4>${Utils.escapeHtml(campaign.name)}</h4>
+                    <button class="btn btn-secondary btn-sm" onclick="Campaigns.hideActiveCampaign()">
+                        ✕ Schließen
+                    </button>
+                </div>
+                
+                <!-- Versand-Optionen -->
+                <div class="send-options">
+                    <div class="form-group">
+                        <label for="activeCampaignSpeed">Versand-Geschwindigkeit:</label>
+                        <select id="activeCampaignSpeed" class="form-control">
+                            <option value="1000">Normal (1s Pause)</option>
+                            <option value="2000" selected>Sicher (2s Pause)</option>
+                            <option value="5000">Langsam (5s Pause)</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>
+                            <input type="checkbox" id="activeCampaignTestMode"> 
+                            Test-Modus (nur erste 2 E-Mails)
+                        </label>
+                    </div>
+                </div>
+                
+                <div class="send-actions">
+                    <button id="startSendBtn" class="btn btn-success btn-large" onclick="Campaigns.executeCampaign('${campaign.id}')">
+                        🚀 Kampagne jetzt senden
+                    </button>
+                </div>
+                
+                <!-- Progress (initially hidden) -->
+                <div id="activeCampaignProgress" class="campaign-progress-section" style="display: none;">
+                    <h4>📊 Versand-Fortschritt</h4>
+                    <div class="progress-bar-container">
+                        <div class="progress-bar">
+                            <div id="activeCampaignProgressBar" class="progress-fill" style="width: 0%"></div>
+                        </div>
+                        <div class="progress-text">
+                            <span id="activeCampaignProgressText">Bereit zum Versand</span>
+                            <span id="activeCampaignProgressCount">0 / ${campaign.stats.total}</span>
+                        </div>
+                    </div>
+                    
+                    <!-- Live-Log -->
+                    <div class="campaign-log">
+                        <h5>📝 Versand-Log</h5>
+                        <div id="activeCampaignLogContainer" class="log-container"></div>
+                    </div>
+                    
+                    <div class="progress-actions">
+                        <button id="pauseSendBtn" class="btn btn-warning" style="display: none;">
+                            ⏸️ Pausieren
+                        </button>
+                        <button id="stopSendBtn" class="btn btn-danger" style="display: none;">
+                            ⏹️ Stoppen
+                        </button>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        section.style.display = 'block';
+        container.scrollIntoView({ behavior: 'smooth' });
+    }
+
+    /**
+     * Führt Kampagnen-Versand aus (DIESELBE Logik wie Mail Wizard)
+     */
+    async function executeCampaign(campaignId) {
+        const campaign = campaigns.find(c => c.id === campaignId);
+        if (!campaign) return;
+
+        try {
+            const sendSpeed = parseInt(document.getElementById('activeCampaignSpeed')?.value) || 2000;
+            const testMode = document.getElementById('activeCampaignTestMode')?.checked || false;
+
+            let recipients = [...campaign.selectedRecipients];
+            if (testMode) {
+                recipients = recipients.slice(0, 2);
+                logToActiveCampaign(`🧪 Test-Modus: Sende nur an ${recipients.length} Empfänger`);
+            }
+
+            // UI für Versand vorbereiten
+            document.getElementById('activeCampaignProgress').style.display = 'block';
+            document.getElementById('startSendBtn').disabled = true;
+            
+            logToActiveCampaign(`🚀 Kampagne gestartet: ${recipients.length} E-Mails`);
+
+            // Versand durchführen (DIESELBE Logik wie Mail Wizard)
+            let sent = 0;
+            let errors = 0;
+            const startTime = Date.now();
+
+            for (let i = 0; i < recipients.length; i++) {
+                const recipient = recipients[i];
+
+                try {
+                    updateActiveCampaignProgress(i + 1, recipients.length, `Sende an ${recipient.email}`);
+                    await sendPersonalizedEmail(campaign, recipient);
+                    sent++;
+                    logToActiveCampaign(`✅ Gesendet an ${recipient.name} (${recipient.email})`);
+                } catch (error) {
+                    errors++;
+                    logToActiveCampaign(`❌ Fehler bei ${recipient.email}: ${error.message}`, 'error');
+                }
+
+                if (i < recipients.length - 1) {
+                    await new Promise(resolve => setTimeout(resolve, sendSpeed));
+                }
+            }
+
+            // Versand abgeschlossen
+            const duration = Math.round((Date.now() - startTime) / 1000);
+            updateActiveCampaignProgress(recipients.length, recipients.length, 'Versand abgeschlossen');
+            logToActiveCampaign(`🎉 Kampagne abgeschlossen: ${sent} gesendet, ${errors} Fehler in ${duration}s`);
+
+            // Kampagne-Status updaten
+            campaign.status = 'sent';
+            campaign.stats.sent = sent;
+            campaign.stats.errors = errors;
+            saveCampaigns();
+            updateCampaignsList();
+
+        } catch (error) {
+            console.error('Campaign execution error:', error);
+            logToActiveCampaign(`❌ Fehler: ${error.message}`, 'error');
+        }
+    }
+
+    // ===== UTILITY FUNCTIONS =====
+
+    function getStatusLabel(status) {
+        const labels = {
+            draft: 'Entwurf',
+            sending: 'Wird gesendet',
+            sent: 'Gesendet',
+            error: 'Fehler'
+        };
+        return labels[status] || status;
+    }
+
+    function saveCampaigns() {
+        try {
+            localStorage.setItem('campaignDrafts', JSON.stringify(campaigns));
+        } catch (error) {
+            console.error('Error saving campaigns:', error);
+        }
+    }
+
+    function logToActiveCampaign(message, type = 'info') {
+        const logContainer = document.getElementById('activeCampaignLogContainer');
+        if (!logContainer) return;
+
+        const timestamp = new Date().toLocaleTimeString('de-DE');
+        const logEntry = document.createElement('div');
+        logEntry.className = `log-entry log-${type}`;
+        logEntry.innerHTML = `<span class="log-time">[${timestamp}]</span> ${message}`;
+
+        logContainer.appendChild(logEntry);
+        logContainer.scrollTop = logContainer.scrollHeight;
+    }
+
+    function updateActiveCampaignProgress(current, total, message) {
+        const progressBar = document.getElementById('activeCampaignProgressBar');
+        const progressText = document.getElementById('activeCampaignProgressText');
+        const progressCount = document.getElementById('activeCampaignProgressCount');
+
+        if (progressBar) {
+            const percentage = (current / total) * 100;
+            progressBar.style.width = percentage + '%';
+        }
+
+        if (progressText) {
+            progressText.textContent = message;
+        }
+
+        if (progressCount) {
+            progressCount.textContent = `${current} / ${total}`;
+        }
+    }
+
+    // Verwende dieselbe sendPersonalizedEmail Funktion wie Mail Wizard
+    async function sendPersonalizedEmail(campaign, recipient) {
+        let personalizedSubject = campaign.subject;
+        let personalizedContent = campaign.content;
+
+        if (window.Templates && typeof Templates.personalizeContent === 'function') {
+            personalizedSubject = Templates.personalizeContent(campaign.subject, recipient);
+            personalizedContent = Templates.personalizeContent(campaign.content, recipient);
+        }
+
+        const config = window.Config ? Config.getConfig() : {
+            serviceId: localStorage.getItem('emailjs_service_id'),
+            templateId: localStorage.getItem('emailjs_template_id'),
+            fromName: localStorage.getItem('fromName')
+        };
+
+        const templateParams = {
+            subject: personalizedSubject,
+            message: personalizedContent,
+            to_email: recipient.email,
+            name: config.fromName,
+            email: recipient.email
+        };
+
+        const response = await emailjs.send(config.serviceId, config.templateId, templateParams);
+
+        if (response.status !== 200) {
+            throw new Error(`EmailJS Status: ${response.status}`);
+        }
+
+        return response;
+    }
+
+    // ===== PUBLIC API =====
+    return {
+        init,
+        loadCampaigns,
+        updateCampaignsList,
+        startCampaign,
+        executeCampaign,
+        previewCampaign: (id) => console.log('Preview campaign:', id),
+        editCampaign: (id) => console.log('Edit campaign:', id),
+        deleteCampaign: (id) => {
+            if (confirm('Kampagne wirklich löschen?')) {
+                campaigns = campaigns.filter(c => c.id !== id);
+                saveCampaigns();
+                updateCampaignsList();
+            }
+        },
+        hideActiveCampaign: () => {
+            document.getElementById('activeCampaignSection').style.display = 'none';
+            activeCampaign = null;
+        },
+        refreshList: () => {
+            loadCampaigns();
+            updateCampaignsList();
+        }
+    };
+})();

--- a/js/mail-wizard.js
+++ b/js/mail-wizard.js
@@ -1382,11 +1382,10 @@ function generateWizardButtons() {
     // ===== WIZARD COMPLETION =====
 
     /**
-     * Schließt Wizard ab und speichert Kampagne (sendet noch NICHT)
+     * Schließt Wizard ab und speichert Kampagne (KEIN Versand!)
      */
     function finishWizard() {
-        console.log('=== SAVE CAMPAIGN DEBUG START ===');
-        console.log('Wizard Data:', wizardData);
+        console.log('=== SAVE CAMPAIGN (WIZARD) ===');
 
         try {
             // Validierung
@@ -1398,7 +1397,7 @@ function generateWizardButtons() {
             // Kampagnen-Objekt erstellen
             const campaignData = {
                 id: generateCampaignId(),
-                name: `Kampagne vom ${new Date().toLocaleDateString('de-DE')}`,
+                name: wizardData.subject || `Kampagne vom ${new Date().toLocaleDateString('de-DE')}`,
                 subject: wizardData.subject,
                 content: wizardData.content,
                 selectedRecipients: wizardData.selectedRecipients.map(email => findRecipientByEmail(email)),
@@ -1413,21 +1412,52 @@ function generateWizardButtons() {
 
             console.log('Campaign created:', campaignData);
 
-            // Kampagne "speichern" (in Memory/LocalStorage)
+            // Kampagne speichern
             saveCampaignDraft(campaignData);
 
-            // Modal schließen
-            hideWizardModal();
+            // Erfolgs-Feedback (EINFACH)
+            showSimpleSuccessMessage(campaignData);
 
-            // Zu Campaign-Übersicht wechseln
-            showCampaignOverview(campaignData);
+            // Wizard schließen nach 2 Sekunden
+            setTimeout(() => {
+                hideWizardModal();
 
-            console.log('=== SAVE CAMPAIGN DEBUG END ===');
+                // Zum Kampagnen-Tab wechseln
+                if (window.App && typeof App.showTab === 'function') {
+                    App.showTab('campaigns');
+                }
+            }, 2000);
 
         } catch (error) {
             console.error('Save campaign error:', error);
             alert(`Fehler beim Speichern der Kampagne: ${error.message}`);
         }
+    }
+
+    /**
+     * Zeigt einfache Erfolgs-Nachricht (KEIN komplexes Modal)
+     */
+    function showSimpleSuccessMessage(campaignData) {
+        const modal = document.getElementById('mailWizardModal');
+        if (!modal) return;
+
+        // Einfache Success-Nachricht
+        modal.innerHTML = `
+            <div class="wizard-modal">
+                <div class="success-message-container">
+                    <div class="success-icon">🎉</div>
+                    <h2>Kampagne gespeichert!</h2>
+                    <div class="success-details">
+                        <p><strong>${campaignData.name}</strong></p>
+                        <p>📧 ${campaignData.stats.total} Empfänger</p>
+                        <p>📅 ${campaignData.createdAt.toLocaleDateString('de-DE')}</p>
+                    </div>
+                    <div class="success-info">
+                        <p>Du wirst zum Kampagnen-Tab weitergeleitet...</p>
+                    </div>
+                </div>
+            </div>
+        `;
     }
 
     /**


### PR DESCRIPTION
## Summary
- simplify `finishWizard` in Mail Wizard to only save campaigns
- show a simple success message and redirect to campaigns tab
- add new **Campaigns** tab UI
- create `campaigns.js` for managing campaigns and sending
- load the Campaigns module and initialize it in the main app

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68596e6197d88323900d0e33365b3d08