### PR TITLE
Fix campaigns tab navigation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -265,6 +265,12 @@ window.App = (function() {
                 // Beim Wechsel zum Mail Wizard sind keine Aktionen erforderlich
                 break;
 
+            case 'campaigns':
+                if (modules.campaigns && typeof modules.campaigns.updateCampaignsList === 'function') {
+                    modules.campaigns.updateCampaignsList();
+                }
+                break;
+
             case 'history':
                 // Verlauf-Tab: zukünftig können hier Daten nachgeladen werden
                 break;
@@ -278,7 +284,7 @@ window.App = (function() {
      */
     function isValidTab(tabName) {
         // Liste der vorhandenen Tabs (muss mit index.html übereinstimmen)
-        const validTabs = ['dashboard', 'templates', 'recipients', 'mailwizard', 'history'];
+        const validTabs = ['dashboard', 'templates', 'recipients', 'mailwizard', 'campaigns', 'history'];
         return validTabs.includes(tabName);
     }
 


### PR DESCRIPTION
## Summary
- add `campaigns` tab handling
- include `campaigns` in the list of valid tabs

## Testing
- `node generate-version.js`
- `node backend/index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68597cfee5a0832392f49fe3ba221ec9