### PR TITLE
Fix attachment integration in mail wizard

### DIFF
--- a/js/mail-wizard.js
+++ b/js/mail-wizard.js
@@ -632,7 +632,111 @@ function generateWizardButtons() {
      * Initialisiert Anhänge-System
      */
     function initializeAttachments() {
-        console.log('Initializing attachments...');
+        console.log('Initializing wizard attachments integration...');
+
+        // DOM braucht einen Moment nach dem Rendern
+        setTimeout(() => {
+            setupAttachmentIntegration();
+        }, 100);
+    }
+
+    function setupAttachmentIntegration() {
+        const fileInput = document.getElementById('attachmentFileInput');
+        const dropZone = document.getElementById('attachmentDropZone');
+        const attachmentList = document.getElementById('attachmentList');
+
+        if (!fileInput || !dropZone) {
+            console.error('Attachment elements not found in DOM');
+            return;
+        }
+
+        // File Input Handler
+        fileInput.addEventListener('change', (e) => {
+            handleWizardFileSelect(e.target.files);
+        });
+
+        // Drop Zone Click Handler
+        dropZone.addEventListener('click', () => {
+            fileInput.click();
+        });
+
+        // Drag & Drop Handlers
+        dropZone.addEventListener('dragover', handleWizardDragOver);
+        dropZone.addEventListener('drop', handleWizardDrop);
+        dropZone.addEventListener('dragleave', handleWizardDragLeave);
+
+        // Initial Display Update
+        updateWizardAttachmentDisplay();
+
+        console.log('✓ Attachment integration setup complete');
+    }
+
+    async function handleWizardFileSelect(files) {
+        if (!window.Attachments) {
+            console.error('Attachments module not available');
+            return;
+        }
+
+        // Show progress indicator
+        const dropZone = document.getElementById('attachmentDropZone');
+        if (dropZone) {
+            dropZone.innerHTML = '<p>📤 Uploading files...</p>';
+        }
+
+        try {
+            // Use Attachments module
+            await Attachments.processFiles(Array.from(files));
+
+            // Update wizard data
+            wizardData.attachments = Attachments.getAttachments();
+
+            // Update display
+            updateWizardAttachmentDisplay();
+
+            // Restore drop zone
+            resetDropZone();
+
+        } catch (error) {
+            handleUploadError(error, files[0]?.name || 'Datei');
+        }
+    }
+
+    function handleWizardDragOver(e) {
+        e.preventDefault();
+        e.currentTarget.classList.add('dragover');
+    }
+
+    function handleWizardDrop(e) {
+        e.preventDefault();
+        e.currentTarget.classList.remove('dragover');
+        handleWizardFileSelect(e.dataTransfer.files);
+    }
+
+    function handleWizardDragLeave(e) {
+        e.currentTarget.classList.remove('dragover');
+    }
+
+    function resetDropZone() {
+        const dropZone = document.getElementById('attachmentDropZone');
+        if (dropZone) {
+            dropZone.innerHTML = '<p>📁 Dateien hier ablegen oder klicken zum Auswählen</p>';
+        }
+    }
+
+    function handleUploadError(error, fileName) {
+        console.error('Upload error:', error);
+
+        let errorMessage = 'Upload fehlgeschlagen';
+        if (error.message.includes('too large')) {
+            errorMessage = 'Datei zu groß (max. 20MB)';
+        } else if (error.message.includes('not allowed')) {
+            errorMessage = 'Dateityp nicht unterstützt';
+        } else if (error.message.includes('server')) {
+            errorMessage = 'Server-Fehler beim Upload';
+        }
+
+        Utils.showToast(`${fileName}: ${errorMessage}`, 'error');
+        resetDropZone();
     }
 
     /**
@@ -1258,22 +1362,41 @@ function generateWizardButtons() {
      * Aktualisiert Attachment-Anzeige im Wizard
      */
     function updateWizardAttachmentDisplay() {
-        const container = document.getElementById('wizardAttachmentList');
+        const container = document.getElementById('attachmentList');
         if (!container) return;
-        
-        if (wizardData.attachments.length === 0) {
-            container.innerHTML = '<p class="placeholder">Keine Attachments vorhanden</p>';
+
+        const attachments = wizardData.attachments || [];
+
+        if (attachments.length === 0) {
+            container.innerHTML = '<p class="placeholder">Keine Anhänge vorhanden</p>';
             return;
         }
-        
-        container.innerHTML = wizardData.attachments.map(att => `
-            <div class="wizard-attachment-item">
-                <span><a href="${att.url}" target="_new">${att.name}</a> (${Utils.formatFileSize(att.size)})</span>
-                <button onclick="MailWizard.insertAttachmentLink('${att.id}')" class="wizard-btn-small">
-                    📝 In Text einfügen
-                </button>
-            </div>
-        `).join('');
+
+        container.innerHTML = `
+        <div class="wizard-attachment-stats">
+            <h4>📎 ${attachments.length} Datei(en) ausgewählt</h4>
+        </div>
+        <div class="wizard-attachment-items">
+            ${attachments.map((att, index) => `
+                <div class="wizard-attachment-item">
+                    <div class="attachment-info">
+                        <span class="attachment-name">📄 ${att.name}</span>
+                        <span class="attachment-size">${Utils.formatFileSize(att.size)}</span>
+                    </div>
+                    <div class="attachment-actions">
+                        <button type="button" class="btn btn-sm btn-secondary" 
+                                onclick="MailWizard.insertAttachmentLink('${att.id}')">
+                            📝 In E-Mail einfügen
+                        </button>
+                        <button type="button" class="btn btn-sm btn-danger" 
+                                onclick="MailWizard.removeWizardAttachment(${index})">
+                            🗑️ Entfernen
+                        </button>
+                    </div>
+                </div>
+            `).join('')}
+        </div>
+        `;
     }
 
     /**
@@ -1290,6 +1413,20 @@ function generateWizardButtons() {
             editor.innerHTML += linkHtml;
             updateWizardPreview();
         }
+    }
+
+    function removeWizardAttachment(index) {
+        if (!wizardData.attachments[index]) return;
+
+        const attachment = wizardData.attachments[index];
+
+        if (window.Attachments) {
+            Attachments.removeAttachment(attachment.id);
+        }
+
+        wizardData.attachments = window.Attachments ? Attachments.getAttachments() : [];
+
+        updateWizardAttachmentDisplay();
     }
 
     // ===== STEP 6: REVIEW =====
@@ -1784,6 +1921,8 @@ function generateWizardButtons() {
         selectMailType,
         selectTemplate,
         insertAttachmentLink,
+        removeWizardAttachment,
+        initializeAttachments,
         
         // Empfänger-Funktionen
         toggleRecipient,

--- a/styles.css
+++ b/styles.css
@@ -3453,3 +3453,94 @@ small {
     50% { transform: translateY(-10px); }
 }
 
+/* === WIZARD ATTACHMENT STYLES === */
+.attachment-drop-zone {
+    border: 2px dashed #667eea;
+    border-radius: 12px;
+    padding: 40px 20px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    background: #f8f9ff;
+    margin-bottom: 20px;
+}
+
+.attachment-drop-zone:hover {
+    border-color: #5a6fd8;
+    background: #f0f4ff;
+    transform: translateY(-2px);
+}
+
+.attachment-drop-zone.dragover {
+    border-color: #4c63d2;
+    background: #e8f0ff;
+    border-style: solid;
+}
+
+.wizard-attachment-stats {
+    background: #e8f5e8;
+    border: 1px solid #27ae60;
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 16px;
+}
+
+.wizard-attachment-stats h4 {
+    margin: 0;
+    color: #27ae60;
+    font-size: 16px;
+}
+
+.wizard-attachment-items {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.wizard-attachment-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px;
+    background: white;
+    border: 2px solid #e9ecef;
+    border-radius: 8px;
+    transition: all 0.3s ease;
+}
+
+.wizard-attachment-item:hover {
+    border-color: #667eea;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.15);
+}
+
+.attachment-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+}
+
+.attachment-name {
+    font-weight: 600;
+    color: #2c3e50;
+    font-size: 14px;
+}
+
+.attachment-size {
+    font-size: 12px;
+    color: #6c757d;
+    font-family: 'Courier New', monospace;
+}
+
+.attachment-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.btn-sm {
+    padding: 6px 12px;
+    font-size: 12px;
+    min-height: 32px;
+}
+


### PR DESCRIPTION
## Summary
- connect attachments module with mail wizard step 5
- update attachment display and add removal logic
- handle upload errors with user friendly messages
- style wizard attachment UI

## Testing
- `npm test` *(fails: could not read package.json)*
- `cd backend && npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68598f6940c4832395a6231c2dd324fa