### PR TITLE
Fix wizard attachments integration

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1587,6 +1587,97 @@ small {
 
 /* === MAIL WIZARD STYLES === */
 
+/* === WIZARD ATTACHMENT STYLES === */
+.attachment-drop-zone {
+    border: 2px dashed #667eea;
+    border-radius: 12px;
+    padding: 40px 20px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    background: #f8f9ff;
+    margin-bottom: 20px;
+}
+
+.attachment-drop-zone:hover {
+    border-color: #5a6fd8;
+    background: #f0f4ff;
+    transform: translateY(-2px);
+}
+
+.attachment-drop-zone.dragover {
+    border-color: #4c63d2;
+    background: #e8f0ff;
+    border-style: solid;
+}
+
+.wizard-attachment-stats {
+    background: #e8f5e8;
+    border: 1px solid #27ae60;
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 16px;
+}
+
+.wizard-attachment-stats h4 {
+    margin: 0;
+    color: #27ae60;
+    font-size: 16px;
+}
+
+.wizard-attachment-items {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.wizard-attachment-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px;
+    background: white;
+    border: 2px solid #e9ecef;
+    border-radius: 8px;
+    transition: all 0.3s ease;
+}
+
+.wizard-attachment-item:hover {
+    border-color: #667eea;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.15);
+}
+
+.attachment-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+}
+
+.attachment-name {
+    font-weight: 600;
+    color: #2c3e50;
+    font-size: 14px;
+}
+
+.attachment-size {
+    font-size: 12px;
+    color: #6c757d;
+    font-family: 'Courier New', monospace;
+}
+
+.attachment-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.btn-sm {
+    padding: 6px 12px;
+    font-size: 12px;
+    min-height: 32px;
+}
+
 /* Mail Wizard Modal */
 .mail-wizard-container {
     background: white;


### PR DESCRIPTION
## Summary
- hook up step 5 of the mail wizard to the `Attachments` module
- add wizard attachment styling for drag/drop zone and list

## Testing
- `npm test --prefix backend` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685995a8be5483239820845f977f6b5d