### PR TITLE
Implement saved templates in Mail Wizard

### DIFF
--- a/css/pages/wizard.css
+++ b/css/pages/wizard.css
@@ -561,6 +561,61 @@
     line-height: 1.3;
 }
 
+/* Zusätzliche Template-Styles */
+.template-section {
+    margin-bottom: 25px;
+}
+
+.template-section h4 {
+    margin: 0 0 12px 0;
+    font-size: 16px;
+    color: #495057;
+    font-weight: 600;
+    border-bottom: 2px solid #e9ecef;
+    padding-bottom: 6px;
+}
+
+.wizard-template-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 15px;
+}
+
+.wizard-template-card[data-type="saved"] {
+    border-color: #28a745;
+}
+
+.wizard-template-card[data-type="saved"]:hover {
+    border-color: #1e7e34;
+}
+
+.wizard-template-card[data-type="saved"].selected {
+    border-color: #28a745;
+    background: #f8fff8;
+}
+
+.template-source {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: rgba(108, 117, 125, 0.1);
+    color: #6c757d;
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+
+.wizard-template-card[data-type="saved"] .template-source {
+    background: rgba(40, 167, 69, 0.1);
+    color: #28a745;
+}
+
+.empty-templates {
+    text-align: center;
+    padding: 40px 20px;
+    color: #6c757d;
+}
+
 /* Step 3: Editor */
 .wizard-toolbar {
     background: #f8f9fa;


### PR DESCRIPTION
## Summary
- load saved templates from localStorage
- show saved templates alongside built-in ones
- allow selecting saved templates
- expose template loader on public API
- style saved-template sections

## Testing
- `npm install --silent`
- `PORT=8080 node index.js &`
- `node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_68599d7dbd0483239231d3613be0c096