### PR TITLE
Update version to 2.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "bcryptjs": "^3.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/generate-version.js
+++ b/generate-version.js
@@ -6,7 +6,7 @@ function generateVersion() {
         const dateStr = now.toISOString().slice(0, 19).replace('T', ' ');
         const timestamp = Math.floor(now.getTime() / 1000);
         const buildNumber = timestamp.toString().slice(-6);
-        const version = `2.0.${buildNumber}`;
+        const version = `2.1.${buildNumber}`;
         const fullVersion = `${version} (${dateStr})`;
         
         const versionData = {
@@ -71,7 +71,7 @@ if (document.readyState === 'loading') {
         
     } catch (error) {
         console.error('Error generating version:', error);
-        const fallbackVersion = '2.0.0';
+        const fallbackVersion = '2.1.0';
         const fallbackDate = new Date().toISOString().slice(0, 19).replace('T', ' ');
         const fallback = `${fallbackVersion} (${fallbackDate})`;
         fs.writeFileSync('version.txt', fallback);

--- a/js/config.js
+++ b/js/config.js
@@ -20,7 +20,7 @@ window.Config = (function() {
         userId: '',
         fromName: '',
         setupCompleted: false,
-        version: '2.0'
+        version: '2.1'
     };
 
     const DEFAULT_SETTINGS = {
@@ -67,7 +67,7 @@ window.Config = (function() {
                 userId: localStorage.getItem('emailjs_user_id') || '',
                 fromName: localStorage.getItem('fromName') || '',
                 setupCompleted: localStorage.getItem('emailjs_configured') === 'true',
-                version: '2.0'
+                version: '2.1'
             };
 
             // Migrierte Config in strukturiertem Format speichern
@@ -361,7 +361,7 @@ window.Config = (function() {
     function createBackup() {
         try {
             return {
-                version: '2.0',
+                version: '2.1',
                 timestamp: new Date().toISOString(),
                 created: Utils.formatDate(new Date()),
                 emailConfig: currentConfig,

--- a/js/version.js
+++ b/js/version.js
@@ -1,5 +1,5 @@
 // Auto-generated version file
-window.APP_VERSION = {"version":"2.0.697398","fullVersion":"2.0.697398 (2025-06-23 16:49:58)","buildDate":"2025-06-23 16:49:58","buildNumber":"697398","timestamp":1750697398};
+window.APP_VERSION = {"version":"2.1.708808","fullVersion":"2.1.708808 (2025-06-23 20:00:08)","buildDate":"2025-06-23 20:00:08","buildNumber":"708808","timestamp":1750708808};
 
 function displayVersion() {
     const versionElements = document.querySelectorAll('.app-version');
@@ -16,7 +16,7 @@ function displayVersion() {
 }
 
 function insertVersionedCSS() {
-    const href = 'css/index.css?v=' + window.APP_VERSION.buildNumber;
+    const href = 'styles.css?v=' + window.APP_VERSION.buildNumber;
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.href = href;
@@ -24,7 +24,7 @@ function insertVersionedCSS() {
     link.onerror = () => {
         const fallback = document.createElement('link');
         fallback.rel = 'stylesheet';
-        fallback.href = 'css/index.css';
+        fallback.href = 'styles.css';
         fallback.onload = () => document.body.classList.add('css-loaded');
         document.head.appendChild(fallback);
     };


### PR DESCRIPTION
## Summary
- bump version numbers to 2.1 across backend and frontend
- regenerate version files

## Testing
- `node generate-version.js`

------
https://chatgpt.com/codex/tasks/task_e_6859b1bd28e88323908fb2f09312a1fe