### PR TITLE
Fix TSM-001: unify toast notifications

### DIFF
--- a/js/landing.js
+++ b/js/landing.js
@@ -296,7 +296,7 @@ function loadCurrentSettings() {
 
     } catch (error) {
         console.error('Error loading settings:', error);
-        Utils.showStatus('settingsStatus', 'Fehler beim Laden der Einstellungen', 'error');
+        Utils.showToast('Fehler beim Laden der Einstellungen', 'error');
     }
 }
 
@@ -315,7 +315,7 @@ function saveSettings() {
 
         // Validierung
         if (!newConfig.serviceId || !newConfig.templateId || !newConfig.userId || !newConfig.fromName) {
-            Utils.showStatus('settingsStatus', 'Bitte alle Felder ausfüllen', 'error');
+            Utils.showToast('Bitte alle Felder ausfüllen', 'error');
             return;
         }
 
@@ -323,7 +323,7 @@ function saveSettings() {
         if (Config) {
             const success = Config.saveConfig(newConfig);
             if (!success) {
-                Utils.showStatus('settingsStatus', 'Fehler beim Speichern der EmailJS-Konfiguration', 'error');
+                Utils.showToast('Fehler beim Speichern der EmailJS-Konfiguration', 'error');
                 return;
             }
         }
@@ -333,7 +333,7 @@ function saveSettings() {
         localStorage.setItem('autoSaveTemplates', document.getElementById('settings-autoSave').checked);
 
         // UI aktualisieren
-        Utils.showStatus('settingsStatus', 'Einstellungen gespeichert!', 'success');
+        Utils.showToast('Einstellungen gespeichert!', 'success');
 
         // Setup-Status neu laden
         setTimeout(() => {
@@ -343,7 +343,7 @@ function saveSettings() {
 
     } catch (error) {
         console.error('Error saving settings:', error);
-        Utils.showStatus('settingsStatus', 'Fehler beim Speichern', 'error');
+        Utils.showToast('Fehler beim Speichern', 'error');
     }
 }
 
@@ -351,19 +351,22 @@ function saveSettings() {
  * Setzt alle Daten zurück
  */
 function resetSettings() {
-    if (confirm('Wirklich alle Daten löschen? Dies kann nicht rückgängig gemacht werden!')) {
-        // Alle relevanten localStorage Keys löschen
-        const keysToDelete = [
+    Utils.showConfirm(
+        'Wirklich alle Daten löschen? Dies kann nicht rückgängig gemacht werden!',
+        () => {
+            // Alle relevanten localStorage Keys löschen
+            const keysToDelete = [
             'emailjs_service_id', 'emailjs_template_id', 'emailjs_user_id', 'fromName',
             'emailjs_configured', 'recipients', 'emailTemplates', 'emailConfig',
             'appSettings', 'sendSpeed', 'autoSaveTemplates'
-        ];
+            ];
 
-        keysToDelete.forEach(key => localStorage.removeItem(key));
+            keysToDelete.forEach(key => localStorage.removeItem(key));
 
-        // Page reload
-        location.reload();
-    }
+            // Page reload
+            location.reload();
+        }
+    );
 }
 
 /**

--- a/js/recipients.js
+++ b/js/recipients.js
@@ -182,7 +182,7 @@ window.Recipients = (function() {
         console.log(`Loading CSV file: ${file.name} (${Utils.formatFileSize(file.size)})`);
 
         if (typeof Papa === 'undefined') {
-            Utils.showStatus('recipientStatus', 'CSV-Parser nicht verfügbar', 'error');
+            Utils.showToast('CSV-Parser nicht verfügbar', 'error');
             return;
         }
 
@@ -197,7 +197,7 @@ window.Recipients = (function() {
         console.log('CSV Parse Results:', results);
         
         if (!results.data || results.data.length === 0) {
-            Utils.showStatus('recipientStatus', 'CSV-Datei ist leer', 'error');
+            Utils.showToast('CSV-Datei ist leer', 'error');
             return;
         }
 
@@ -206,7 +206,7 @@ window.Recipients = (function() {
         importErrors = processedData.errors;
         
         if (newRecipients.length === 0) {
-            Utils.showStatus('recipientStatus', 'Keine gültigen E-Mail-Adressen gefunden', 'error');
+            Utils.showToast('Keine gültigen E-Mail-Adressen gefunden', 'error');
             showImportErrors();
             return;
         }
@@ -379,7 +379,7 @@ window.Recipients = (function() {
      */
     function handleCSVParseError(error) {
         console.error('CSV Parse Error:', error);
-        Utils.showStatus('recipientStatus', `CSV-Parse-Fehler: ${error.message}`, 'error');
+        Utils.showToast(`CSV-Parse-Fehler: ${error.message}`, 'error');
     }
 
     // ===== RECIPIENT MANAGEMENT =====
@@ -458,7 +458,7 @@ window.Recipients = (function() {
         if (nameInput) nameInput.value = '';
         if (emailInput) emailInput.value = '';
 
-        Utils.showStatus('recipientStatus', `Empfänger ${email} hinzugefügt`, 'success');
+        Utils.showToast(`Empfänger ${email} hinzugefügt`, 'success');
     }
 
     function addManual() {
@@ -501,9 +501,9 @@ window.Recipients = (function() {
         
         if (addedCount > 0) {
             updateDisplay();
-            Utils.showStatus('recipientStatus', `${addedCount} Test-Empfänger hinzugefügt`, 'success');
+            Utils.showToast(`${addedCount} Test-Empfänger hinzugefügt`, 'success');
         } else {
-            Utils.showStatus('recipientStatus', 'Alle Test-Empfänger bereits vorhanden', 'info');
+            Utils.showToast('Alle Test-Empfänger bereits vorhanden', 'info');
         }
     }
 
@@ -512,7 +512,7 @@ window.Recipients = (function() {
      */
     function clear() {
         if (recipients.length === 0) {
-            Utils.showStatus('recipientStatus', 'Keine Empfänger vorhanden', 'info');
+            Utils.showToast('Keine Empfänger vorhanden', 'info');
             return;
         }
         
@@ -527,7 +527,7 @@ window.Recipients = (function() {
         updateDisplay();
         persistRecipients();
         
-        Utils.showStatus('recipientStatus', `${count} Empfänger gelöscht`, 'success');
+        Utils.showToast(`${count} Empfänger gelöscht`, 'success');
         console.log('All recipients cleared');
     }
 
@@ -536,7 +536,7 @@ window.Recipients = (function() {
      */
     function exportCSV() {
         if (recipients.length === 0) {
-            Utils.showStatus('recipientStatus', 'Keine Empfänger vorhanden', 'info');
+            Utils.showToast('Keine Empfänger vorhanden', 'info');
             return;
         }
 
@@ -548,7 +548,7 @@ window.Recipients = (function() {
         const csvContent = lines.join('\n');
         const filename = `recipients-${Utils.getTimestampForFilename()}.csv`;
         Utils.downloadFile(csvContent, filename, 'text/csv');
-        Utils.showStatus('recipientStatus', 'CSV exportiert', 'success');
+        Utils.showToast('CSV exportiert', 'success');
     }
 
     // ===== UTILITY FUNCTIONS =====
@@ -707,7 +707,7 @@ window.Recipients = (function() {
         }
 
         const messageType = stats.errors > stats.added ? 'error' : 'success';
-        Utils.showStatus('recipientStatus', message, messageType);
+        Utils.showToast(message, messageType);
         
         if (stats.errors > 0) {
             setTimeout(showImportErrors, 1000);
@@ -740,7 +740,7 @@ window.Recipients = (function() {
      * @param {string} message - Fehlermeldung
      */
     function showImportError(message) {
-        Utils.showStatus('recipientStatus', message, 'error');
+        Utils.showToast(message, 'error');
     }
 
     // ===== GETTERS & INFO =====

--- a/js/sender.js
+++ b/js/sender.js
@@ -71,7 +71,7 @@ window.Sender = (function() {
             // Pre-Flight Checks
             const validationResult = validateCampaignStart();
             if (!validationResult.valid) {
-                Utils.showStatus('sendStatus', validationResult.message, 'error');
+                Utils.showToast(validationResult.message, 'error');
                 return;
             }
 
@@ -86,7 +86,7 @@ window.Sender = (function() {
             
         } catch (error) {
             console.error('Campaign start error:', error);
-            Utils.showStatus('sendStatus', `Kampagne-Fehler: ${error.message}`, 'error');
+            Utils.showToast(`Kampagne-Fehler: ${error.message}`, 'error');
             stop();
         }
     }
@@ -103,7 +103,7 @@ window.Sender = (function() {
             // Pre-Flight Checks
             const validationResult = validateCampaignData(campaignData);
             if (!validationResult.valid) {
-                Utils.showStatus('sendStatus', validationResult.message, 'error');
+                Utils.showToast(validationResult.message, 'error');
                 return;
             }
 
@@ -118,7 +118,7 @@ window.Sender = (function() {
 
         } catch (error) {
             console.error('Campaign start error:', error);
-            Utils.showStatus('sendStatus', `Kampagne-Fehler: ${error.message}`, 'error');
+            Utils.showToast(`Kampagne-Fehler: ${error.message}`, 'error');
             stop();
         }
     }
@@ -277,7 +277,7 @@ window.Sender = (function() {
     async function executeCampaign() {
         const recipients = currentCampaign.recipients;
         
-        Utils.showStatus('sendStatus', 'Kampagne gestartet...', 'success');
+        Utils.showToast('Kampagne gestartet...', 'success');
 
         ProgressManager.init({
             containerId: 'sendProgressContainer',
@@ -519,7 +519,7 @@ async function sendSingleEmail(recipient) {
         }
 
         campaignPaused = true;
-        Utils.showStatus('sendStatus', 'Kampagne pausiert...', 'info');
+        Utils.showToast('Kampagne pausiert...', 'info');
         
         console.log('Campaign paused');
     }
@@ -534,7 +534,7 @@ async function sendSingleEmail(recipient) {
         }
 
         campaignPaused = false;
-        Utils.showStatus('sendStatus', 'Kampagne fortgesetzt...', 'success');
+        Utils.showToast('Kampagne fortgesetzt...', 'success');
         
         console.log('Campaign resumed');
     }
@@ -662,7 +662,7 @@ async function sendSingleEmail(recipient) {
             messageType = 'error';
         }
         
-        Utils.showStatus('sendStatus', message, messageType);
+        Utils.showToast(message, messageType);
         
         // Detaillierte Statistiken loggen
         console.log('Campaign Results:', {

--- a/js/utils.js
+++ b/js/utils.js
@@ -127,27 +127,8 @@ window.Utils = (function() {
     function showStatus(elementId, message, type = 'info') {
         console.log(`Status [${type}] for ${elementId}:`, message);
 
-        const element = document.getElementById(elementId);
-        if (!element) {
-            console.warn(`Status element not found: ${elementId} - using console log only`);
-            // Fallback: Console-only status
-            const prefix = type === 'error' ? '❌' : type === 'success' ? '✅' : 'ℹ️';
-            console.log(`${prefix} ${message}`);
-            return;
-        }
-
-        element.textContent = message;
-        element.className = `status ${type}`;
-
-        // Auto-clear nach 5 Sekunden für success/info
-        if (type === 'success' || type === 'info') {
-            setTimeout(() => {
-                if (element.textContent === message) {
-                    element.textContent = '';
-                    element.className = 'status';
-                }
-            }, 5000);
-        }
+        // Legacy API-Unterstützung: ElementId wird ignoriert
+        showToast(message, type);
     }
 
     /**

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -407,14 +407,7 @@ window.Wizard = (function() {
      * Zeigt Test-Erfolg an
      */
     function showTestSuccess() {
-        const result = document.getElementById('testResult');
-        if (result) {
-            result.innerHTML = `
-                <div class="test-result success-box">
-                    ✅ Test-E-Mail erfolgreich gesendet! Prüfe dein Postfach.
-                </div>
-            `;
-        }
+        Utils.showToast('✅ Test-E-Mail erfolgreich gesendet! Prüfe dein Postfach.', 'success');
     }
 
     /**
@@ -422,15 +415,11 @@ window.Wizard = (function() {
      * @param {string} errorMessage - Fehlermeldung
      */
     function showTestError(errorMessage) {
-        const result = document.getElementById('testResult');
-        if (result) {
-            result.innerHTML = `
-                <div class="test-result error-box">
-                    ❌ Fehler beim Senden: ${errorMessage}<br>
-                    Prüfe deine EmailJS-Konfiguration.
-                </div>
-            `;
-        }
+        Utils.showToast(
+            `❌ Fehler beim Senden: ${errorMessage}<br>Prüfe deine EmailJS-Konfiguration.`,
+            'error',
+            8000
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- replace `showStatus` implementation with toast backend
- convert wizard test messages to toasts
- show CSV import/export notifications via toast
- update campaign status messaging to toast
- migrate landing settings messages and reset confirmation to toast

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859b4853e308323a3a878626f611d4a