### PR TITLE
Fix emojis in tutorial

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -153,7 +153,7 @@
         }
 
         .url-link::before {
-            content: '\ud83d\udd17';
+            content: '🔗';
             position: absolute;
             top: 8px;
             right: 12px;
@@ -244,7 +244,7 @@
         }
         
         .warning::before {
-            content: '\u26a0\ufe0f';
+            content: '⚠️';
             position: absolute;
             top: 15px;
             right: 15px;
@@ -262,7 +262,7 @@
         }
         
         .success::before {
-            content: '\ud83c\udf89';
+            content: '🎉';
             position: absolute;
             top: 15px;
             right: 15px;


### PR DESCRIPTION
## Summary
- show actual emoji icons on the tutorial page instead of escaped Unicode strings

## Testing
- `npm install`
- `PORT=8080 node index.js &`
- `node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_6859cef6bb848323b5957c5629a50fa1