### PR TITLE
Fix tooltip UX and preview issues

### DIFF
--- a/css/components/help-system.css
+++ b/css/components/help-system.css
@@ -11,27 +11,55 @@
 
 .help-tooltip {
     position: absolute;
-    background: white;
-    border: 1px solid #e1e5e9;
-    border-radius: 8px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
-    max-width: 320px;
-    min-width: 250px;
+    background: #2d3748;
+    color: white;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    max-width: 280px;
+    min-width: 200px;
     pointer-events: auto;
     opacity: 0;
-    transform: scale(0.9);
-    transition: all 0.3s ease;
+    transform: translateY(-5px);
+    transition: all 0.2s ease;
     z-index: 10002;
+    font-size: 13px;
 }
 
 .help-tooltip.show {
     opacity: 1;
-    transform: scale(1);
+    transform: translateY(0);
+}
+
+.help-tooltip::after {
+    content: '';
+    position: absolute;
+    border: 4px solid transparent;
+}
+
+.help-tooltip[data-placement="bottom"]::after {
+    top: -8px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-bottom-color: #2d3748;
+}
+
+.help-tooltip[data-placement="top"]::after {
+    bottom: -8px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-top-color: #2d3748;
+}
+
+.tooltip-title {
+    font-weight: 600;
+    margin-bottom: 6px;
+    color: #e2e8f0;
+    font-size: 12px;
 }
 
 .help-tooltip.hide {
     opacity: 0;
-    transform: scale(0.9);
+    transform: translateY(-5px);
 }
 
 .help-tooltip-header {
@@ -71,10 +99,8 @@
 }
 
 .help-tooltip-body {
-    padding: 16px;
-    font-size: 13px;
-    line-height: 1.5;
-    color: #2d3748;
+    padding: 12px 14px;
+    line-height: 1.4;
 }
 
 .help-content p {
@@ -131,13 +157,12 @@
 }
 
 .help-tip {
-    background: #d4edda;
-    border: 1px solid #c3e6cb;
+    background: rgba(255,255,255,0.1);
     border-radius: 4px;
-    padding: 8px;
-    margin: 8px 0;
-    color: #155724;
-    font-size: 12px;
+    padding: 6px 8px;
+    margin: 6px 0;
+    font-size: 11px;
+    line-height: 1.3;
 }
 
 .help-tips {
@@ -164,36 +189,42 @@
 
 /* Help Indicator */
 .help-indicator {
-    position: absolute;
-    top: -5px;
-    right: -10px;
-    background: #4a90e2;
+    position: relative;
+    display: inline-flex;
+    margin-left: 6px;
+    background: #6c757d;
     color: white;
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     border-radius: 50%;
-    font-size: 10px;
-    font-weight: bold;
-    display: flex;
+    font-size: 9px;
+    font-weight: 600;
     align-items: center;
     justify-content: center;
-    cursor: pointer;
-    z-index: 10;
-    transition: all 0.2s;
+    cursor: help;
+    opacity: 0.7;
+    transition: all 0.2s ease;
+    vertical-align: middle;
 }
 
 .help-indicator:hover {
-    background: #357abd;
+    background: #4a90e2;
+    opacity: 1;
     transform: scale(1.1);
 }
 
-/* Label-spezifische Indicator */
 label .help-indicator {
     position: relative;
     top: 0;
     right: 0;
-    margin-left: 8px;
-    display: inline-flex;
+    margin-left: 6px;
+}
+
+.form-group .help-indicator {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    margin: 0;
 }
 
 /* Mobile Optimierung */

--- a/js/help-system.js
+++ b/js/help-system.js
@@ -70,22 +70,18 @@ window.HelpSystem = (function() {
 
         // KOMPLIZIERT: Mail Wizard Steps
         'wizard-step-1-mailtype': {
-            title: '📝 Mail-Typ auswählen',
+            title: 'Mail-Typ',
             content: `
                 <div class="help-content">
-                    <p>Wähle den passenden Typ für deine E-Mail:</p>
-                    <ul>
-                        <li><strong>Newsletter:</strong> Regelmäßige Updates</li>
-                        <li><strong>Ankündigung:</strong> Wichtige Neuigkeiten</li>
-                        <li><strong>Update:</strong> Persönliche Nachrichten</li>
-                        <li><strong>Individuell:</strong> Eigenes Design</li>
-                    </ul>
+                    <p>Wähle je nach Zweck:</p>
                     <div class="help-tip">
-                        💡 Der Typ bestimmt verfügbare Templates
+                        • <strong>Newsletter:</strong> Regelmäßige Updates<br>
+                        • <strong>Ankündigung:</strong> Wichtige News<br>
+                        • <strong>Individuell:</strong> Eigenes Design
                     </div>
                 </div>
             `,
-            placement: 'top',
+            placement: 'bottom',
             trigger: 'hover'
         },
 
@@ -125,6 +121,28 @@ window.HelpSystem = (function() {
             `,
             placement: 'left',
             trigger: 'focus'
+        },
+
+        'wizard-subject-help': {
+            title: 'Betreff-Tipps',
+            content: `
+                <div class="help-content">
+                    <p>Nutze Platzhalter wie <code>{{name}}</code> für Personalisierung.</p>
+                </div>
+            `,
+            placement: 'bottom',
+            trigger: 'hover'
+        },
+
+        'wizard-content-help': {
+            title: 'Inhalt bearbeiten',
+            content: `
+                <div class="help-content">
+                    <p>Verwende HTML oder Text. Platzhalter wie {{name}} werden beim Versand ersetzt.</p>
+                </div>
+            `,
+            placement: 'bottom',
+            trigger: 'hover'
         },
 
         'wizard-step-4-recipients': {
@@ -299,12 +317,27 @@ Anna Schmidt,anna@example.com
         if (!helpId || !HELP_CONTENT[helpId]) return;
 
         const config = HELP_CONTENT[helpId];
-        
-        // Event Listeners basierend auf Trigger
+        let hoverTimer;
+
         switch (config.trigger) {
             case 'hover':
-                element.addEventListener('mouseenter', () => showTooltip(element, helpId));
-                element.addEventListener('mouseleave', () => hideTooltip());
+                element.addEventListener('mouseenter', () => {
+                    clearTimeout(hoverTimer);
+                    hoverTimer = setTimeout(() => {
+                        showTooltip(element, helpId);
+                    }, 300);
+                });
+
+                element.addEventListener('mouseleave', () => {
+                    clearTimeout(hoverTimer);
+                    if (activeTooltip) {
+                        setTimeout(() => {
+                            if (!activeTooltip?.matches(':hover')) {
+                                hideTooltip();
+                            }
+                        }, 100);
+                    }
+                });
                 break;
             case 'focus':
                 element.addEventListener('focus', () => showTooltip(element, helpId));
@@ -318,14 +351,12 @@ Anna Schmidt,anna@example.com
                 break;
         }
 
-        // Visual indicator hinzufügen
         if (!element.querySelector('.help-indicator')) {
             const indicator = document.createElement('span');
             indicator.className = 'help-indicator';
             indicator.innerHTML = '?';
-            indicator.title = 'Hilfe verfügbar';
-            
-            // Positioning based on element type
+            indicator.title = 'Hilfe anzeigen';
+
             if (element.tagName === 'LABEL') {
                 element.appendChild(indicator);
             } else {
@@ -340,34 +371,37 @@ Anna Schmidt,anna@example.com
      */
     function showTooltip(element, helpId) {
         clearTimeout(tooltipTimeout);
-        hideTooltip(); // Alten Tooltip verstecken
+        hideTooltip();
 
         const config = HELP_CONTENT[helpId];
         const container = document.getElementById('helpTooltipContainer');
 
         const tooltip = document.createElement('div');
         tooltip.className = 'help-tooltip';
+        tooltip.dataset.placement = config.placement;
         tooltip.innerHTML = `
-            <div class="help-tooltip-header">
-                <h4>${config.title}</h4>
-                <button class="help-tooltip-close" onclick="HelpSystem.hideTooltip()">&times;</button>
-            </div>
             <div class="help-tooltip-body">
+                <div class="tooltip-title">${config.title}</div>
                 ${config.content}
             </div>
         `;
 
         container.appendChild(tooltip);
-        
-        // Positioning
-        positionTooltip(tooltip, element, config.placement);
-        
-        // Animation
+
         requestAnimationFrame(() => {
-            tooltip.classList.add('show');
+            positionTooltip(tooltip, element, config.placement);
+            setTimeout(() => {
+                tooltip.classList.add('show');
+            }, 10);
         });
 
         activeTooltip = tooltip;
+
+        if (config.trigger === 'hover') {
+            tooltipTimeout = setTimeout(() => {
+                hideTooltip();
+            }, 5000);
+        }
     }
 
     /**

--- a/js/mail-wizard.js
+++ b/js/mail-wizard.js
@@ -396,8 +396,47 @@ function resetWizardData() {
      * Generiert Schritt 3: Editor
      */
     function generateStep3() {
-        return `\n        <div id="mail-wizard-step-3" class="wizard-step-content">\n            <div class="step-intro">\n                <h3 class="step-title">✏️ Inhalt bearbeiten</h3>\n                <p class="step-subtitle">Betreff und E-Mail-Inhalt anpassen</p>\n            </div>\n            \n            <div class="wizard-editor-container">\n                <div class="form-group">\n                    <label for="wizardSubject">Betreff *</label>\n                    <input type="text" id="wizardSubject" class="form-control" placeholder="E-Mail Betreff eingeben...">\n                    <small class="form-hint">Verwende {{name}} für Personalisierung</small>\n                </div>\n                \n                <div class="wizard-editor-toolbar">\n                    <button type="button" onclick="MailWizard.formatText('bold')" title="Fett">\n                        <strong>B</strong>\n                    </button>\n                    <button type="button" onclick="MailWizard.formatText('italic')" title="Kursiv">\n                        <em>I</em>\n                    </button>\n                    <button type="button" onclick="MailWizard.insertVariable('{{name}}')" title="Name einfügen">\n                        {{name}}\n                    </button>\n                </div>\n                \n                <div class="form-group">\n                    <label for="wizardVisualEditor">E-Mail Inhalt</label>\n                    <div id="wizardVisualEditor" class="wizard-visual-editor" contenteditable="true">\n                        <!-- Inhalt wird dynamisch geladen -->\n                    </div>\n                </div>\n                \n                <div class="wizard-preview">\n                    <h4>Live Vorschau:</h4>\n                    <div id="wizardEmailPreview" class="email-preview">\n                        <!-- Vorschau wird dynamisch generiert -->\n                    </div>\n                </div>\n            </div>\n        </div>\n    `;
+        return `
+        <div id="mail-wizard-step-3" class="wizard-step-content">
+            <div class="step-intro">
+                <h3 class="step-title">✏️ Inhalt bearbeiten</h3>
+                <p class="step-subtitle">Betreff und E-Mail-Inhalt anpassen</p>
+            </div>
+            
+            <div class="wizard-editor-container">
+                <div class="editor-panel">
+                    <div class="form-group">
+                        <label for="wizardSubject">
+                            Betreff *
+                            <span class="help-indicator" data-help="wizard-subject-help">?</span>
+                        </label>
+                        <input type="text" id="wizardSubject" class="form-control" \
+                               placeholder="E-Mail Betreff eingeben...">
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="wizardVisualEditor">
+                            E-Mail Inhalt
+                            <span class="help-indicator" data-help="wizard-content-help">?</span>
+                        </label>
+                        <div id="wizardVisualEditor" class="wizard-visual-editor" \
+                             contenteditable="true" \
+                             placeholder="Hier deinen E-Mail-Inhalt eingeben...">
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="preview-panel">
+                    <h4>📱 Live-Vorschau</h4>
+                    <div id="wizardEmailPreview" class="wizard-email-preview">
+                        <!-- Live Preview wird hier angezeigt -->
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
     }
+
 
     /**
      * Generiert Schritt 4: Empfänger
@@ -1145,53 +1184,52 @@ function generateWizardButtons() {
      * Initialisiert Editor
      */
     function initializeEditor() {
-        console.log('Initializing editor for step 3'); // DEBUG
-
         const subjectInput = document.getElementById('wizardSubject');
         const visualEditor = document.getElementById('wizardVisualEditor');
+        const previewContainer = document.getElementById('wizardEmailPreview');
+
+        if (!previewContainer) {
+            console.warn('Preview container missing, creating...');
+            const newPreviewContainer = document.createElement('div');
+            newPreviewContainer.id = 'wizardEmailPreview';
+            newPreviewContainer.className = 'wizard-email-preview';
+            const editorContainer = document.querySelector('.wizard-editor-container');
+            if (editorContainer) {
+                editorContainer.appendChild(newPreviewContainer);
+            }
+        }
 
         if (subjectInput) {
             subjectInput.value = wizardData.subject || '';
             subjectInput.addEventListener('input', (e) => {
                 wizardData.subject = e.target.value;
-                console.log('Subject updated:', wizardData.subject); // DEBUG
+                updateWizardPreview();
             });
-        } else {
-            console.error('wizardSubject input not found!'); // DEBUG
         }
 
         if (visualEditor) {
-            // Template-Content laden wenn verfügbar
             if (wizardData.content) {
-                // HTML zu editierbaren Content konvertieren
                 const tempDiv = document.createElement('div');
                 tempDiv.innerHTML = wizardData.content;
-
-                // Body-Content extrahieren falls HTML-Template
                 const bodyDiv = tempDiv.querySelector('body > div');
                 let editorContent = bodyDiv ? bodyDiv.innerHTML : wizardData.content;
 
-                // Falls immer noch komplexes HTML, vereinfachen
                 if (editorContent.includes('<!DOCTYPE') || editorContent.includes('<html>')) {
-                    editorContent = 'Hallo {{name}}! \uD83D\uDC4B\n\nHier ist dein w\u00f6chentliches Update mit den wichtigsten Neuigkeiten.\n\nUpdate-Inhalt...';
+                    editorContent = 'Hallo {{name}}! \uD83D\uDC4B\n\nHier ist dein w\u00f6chentliches Update...\n\nViele Gr\u00fc\u00dfe!';
                 }
 
                 visualEditor.innerHTML = editorContent;
             } else {
-                // Fallback Content
                 visualEditor.innerHTML = 'Hallo {{name}}! \uD83D\uDC4B\n\nIhr E-Mail-Inhalt hier...';
             }
 
-            // Event Listener f\u00fcr Live-Updates
             visualEditor.addEventListener('input', () => {
-                console.log('Editor content changed'); // DEBUG
                 updateWizardPreview();
             });
 
-            // Initial Preview Update
-            setTimeout(updateWizardPreview, 100);
-        } else {
-            console.error('wizardVisualEditor not found!'); // DEBUG
+            setTimeout(() => {
+                updateWizardPreview();
+            }, 100);
         }
     }
 


### PR DESCRIPTION
## Summary
- redesign tooltip indicator positioning and tooltip style
- refine help content for mail type selection
- add per-field help entries and smoother hover behavior
- show tooltips with subtle layout and auto-hide
- overhaul mail wizard step 3 HTML layout
- ensure editor initializes live preview container

## Testing
- `node backend/test-auth.js` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_685efdca2cc083238586c7d0679ad908