### PR TITLE
Expand wizard to nearly full-screen on desktop

### DIFF
--- a/css/components/forms.css
+++ b/css/components/forms.css
@@ -1,13 +1,14 @@
 /* === FORMS === */
 .form-group {
-    margin-bottom: 20px;
+    margin-bottom: 30px;
 }
 
-label {
+.form-group label {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 10px;
     display: block;
-    margin-bottom: 8px;
-    font-weight: 500;
-    color: #34495e;
+    color: #2c3e50;
 }
 
 input[type="text"],
@@ -16,14 +17,13 @@ input[type="password"],
 select,
 textarea,
 .form-control {
-    width: 100%;
-    padding: 12px 16px;
-    border: 2px solid #e9ecef;
+    font-size: 15px;
+    padding: 14px 18px;
     border-radius: 8px;
-    font-size: 16px;
-    transition: border-color 0.3s;
-    box-sizing: border-box;
-    font-family: inherit;
+    border: 2px solid #e9ecef;
+    transition: all 0.3s ease;
+    width: 100%;
+    background: white;
 }
 
 input:focus,
@@ -31,8 +31,8 @@ select:focus,
 textarea:focus,
 .form-control:focus {
     outline: none;
-    border-color: #4a90e2;
-    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.1);
+    border-color: #667eea;
+    box-shadow: 0 0 0 4px rgba(102, 126, 234, 0.1);
 }
 
 small {
@@ -349,4 +349,35 @@ small {
 .send-attachment-summary small {
     color: #6c757d;
     font-size: 12px;
+}
+
+.input-group {
+    display: flex;
+    gap: 15px;
+    align-items: flex-end;
+}
+
+.input-group .form-group {
+    flex: 1;
+    margin-bottom: 0;
+}
+
+.step-intro {
+    margin-bottom: 40px;
+    padding-bottom: 25px;
+    border-bottom: 2px solid #e9ecef;
+}
+
+.step-title {
+    font-size: 28px;
+    margin-bottom: 12px;
+    color: #2c3e50;
+    font-weight: 700;
+}
+
+.step-subtitle {
+    color: #6c757d;
+    margin-bottom: 0;
+    font-size: 18px;
+    line-height: 1.5;
 }

--- a/css/pages/wizard.css
+++ b/css/pages/wizard.css
@@ -1362,3 +1362,439 @@
         padding: 20px;
     }
 }
+/* === VOLLBREITE WIZARD MODALS === */
+.wizard-modal {
+    background: white;
+    border-radius: 15px;
+    box-shadow: 0 15px 40px rgba(0,0,0,0.2);
+    width: 98%;
+    max-width: none;
+    max-height: 90vh;
+    overflow: hidden;
+    position: relative;
+    z-index: 1001;
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;
+}
+
+.wizard-modal.large {
+    width: 98%;
+    max-width: none;
+    max-height: 92vh;
+}
+
+.mail-wizard-container {
+    background: white;
+    border-radius: 15px;
+    box-shadow: 0 15px 40px rgba(0,0,0,0.2);
+    width: 98%;
+    max-width: none;
+    max-height: 90vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    animation: slideUp 0.3s ease;
+    margin: 0 auto;
+}
+
+/* Wizard Overlay - weniger Padding für mehr Platz */
+.wizard-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.75);
+    backdrop-filter: blur(4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    animation: fadeIn 0.3s ease;
+    padding: 1vh 1vw;
+}
+
+/* Content Area maximieren */
+.wizard-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 30px 50px;
+    max-height: calc(90vh - 200px);
+    min-height: 500px;
+}
+
+/* Header anpassen */
+.wizard-header {
+    background: linear-gradient(135deg, #4a90e2, #357abd);
+    color: white;
+    padding: 25px 50px;
+    text-align: center;
+    position: relative;
+    flex-shrink: 0;
+}
+
+.wizard-header h1,
+.wizard-header h2 {
+    margin: 0 0 10px 0;
+    font-size: 32px;
+    font-weight: 600;
+}
+
+/* Progress Indicator anpassen */
+.wizard-progress {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.wizard-step-circle {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    font-size: 18px;
+    transition: all 0.3s ease;
+    border: 2px solid rgba(255,255,255,0.4);
+}
+
+.step-line {
+    width: 80px;
+    height: 4px;
+    background: rgba(255,255,255,0.3);
+    margin: 0 10px;
+    border-radius: 2px;
+    transition: all 0.3s ease;
+}
+
+/* Buttons Container */
+.wizard-buttons {
+    flex-shrink: 0;
+    position: relative;
+    bottom: 0;
+    background: #f8f9fa;
+    border-top: 1px solid #e9ecef;
+    padding: 25px 50px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    z-index: 1000;
+    min-height: 80px;
+}
+
+/* Buttons größer machen */
+.wizard-buttons .btn {
+    padding: 12px 30px;
+    font-size: 16px;
+    font-weight: 600;
+    border-radius: 8px;
+    min-width: 140px;
+}
+
+/* RESPONSIVE: Kleinere Bildschirme */
+@media (max-width: 1200px) {
+    .wizard-modal,
+    .mail-wizard-container {
+        width: 95%;
+    }
+    
+    .wizard-content {
+        padding: 25px 40px;
+    }
+    
+    .wizard-header {
+        padding: 20px 40px;
+    }
+    
+    .wizard-buttons {
+        padding: 20px 40px;
+    }
+}
+
+@media (max-width: 768px) {
+    .wizard-modal,
+    .mail-wizard-container {
+        width: 95%;
+        max-height: 95vh;
+        margin: 0;
+    }
+    
+    .wizard-overlay {
+        padding: 2.5vh 2.5vw;
+    }
+    
+    .wizard-content {
+        padding: 20px 25px;
+        min-height: 400px;
+    }
+    
+    .wizard-header {
+        padding: 20px 25px;
+    }
+    
+    .wizard-header h1,
+    .wizard-header h2 {
+        font-size: 24px;
+    }
+    
+    .wizard-buttons {
+        padding: 20px 25px;
+        flex-direction: column;
+        gap: 12px;
+    }
+    
+    .wizard-buttons .btn {
+        width: 100%;
+        min-width: auto;
+    }
+    
+    .wizard-step-circle {
+        width: 40px;
+        height: 40px;
+        font-size: 16px;
+    }
+    
+    .step-line {
+        width: 50px;
+        height: 3px;
+    }
+}
+
+/* Ultra-wide Displays (> 1920px) */
+@media (min-width: 1920px) {
+    .wizard-modal,
+    .mail-wizard-container {
+        width: 96%;
+        max-height: 88vh;
+    }
+    
+    .wizard-content {
+        padding: 40px 80px;
+        min-height: 600px;
+    }
+    
+    .wizard-header {
+        padding: 30px 80px;
+    }
+    
+    .wizard-header h1,
+    .wizard-header h2 {
+        font-size: 36px;
+    }
+    
+    .wizard-buttons {
+        padding: 30px 80px;
+    }
+}
+/* === STEP 3 VOLLBREITE EDITOR === */
+.wizard-editor-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 40px;
+    min-height: 600px;
+    margin-top: 20px;
+}
+
+.editor-panel,
+.preview-panel {
+    background: white;
+    border-radius: 12px;
+    padding: 25px;
+    border: 1px solid #e9ecef;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.08);
+    min-height: 550px;
+}
+
+.preview-panel h4 {
+    margin: 0 0 20px 0;
+    color: #2c3e50;
+    font-size: 18px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+}
+
+.wizard-visual-editor {
+    min-height: 350px;
+    border: 2px solid #e9ecef;
+    border-radius: 10px;
+    padding: 20px;
+    background: white;
+    font-family: Arial, sans-serif;
+    line-height: 1.6;
+    font-size: 15px;
+    transition: border-color 0.3s ease;
+    overflow-y: auto;
+    resize: vertical;
+}
+
+.wizard-visual-editor:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 4px rgba(102, 126, 234, 0.1);
+}
+
+.editor-toolbar {
+    display: flex;
+    gap: 12px;
+    margin-top: 15px;
+    padding: 12px 16px;
+    background: #f8f9fa;
+    border-radius: 8px;
+    border: 1px solid #e9ecef;
+    flex-wrap: wrap;
+}
+
+.btn-editor {
+    padding: 8px 16px;
+    border: 1px solid #d1d5db;
+    background: white;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 13px;
+    transition: all 0.2s ease;
+    color: #374151;
+    font-weight: 500;
+}
+
+.wizard-email-preview-container {
+    border: 1px solid #e9ecef;
+    border-radius: 10px;
+    background: white;
+    min-height: 400px;
+    position: relative;
+    overflow: hidden;
+}
+
+.wizard-email-preview-container iframe {
+    width: 100%;
+    height: 400px;
+    border: none;
+    background: white;
+    border-radius: 10px;
+}
+
+.preview-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    padding: 12px 0;
+    border-bottom: 1px solid #e9ecef;
+}
+
+.preview-controls .btn {
+    padding: 6px 16px;
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.form-control-sm {
+    padding: 6px 12px;
+    font-size: 13px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background: white;
+    min-width: 120px;
+}
+
+@media (max-width: 1024px) {
+    .wizard-editor-container {
+        grid-template-columns: 1fr;
+        gap: 25px;
+    }
+    
+    .preview-panel {
+        order: -1;
+    }
+    
+    .wizard-visual-editor {
+        min-height: 250px;
+    }
+    
+    .wizard-email-preview-container iframe {
+        height: 300px;
+    }
+}
+/* === VOLLBREITE STEP OPTIMIERUNGEN === */
+
+.wizard-mail-types {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 25px;
+    margin-top: 20px;
+}
+
+.wizard-mail-type-card {
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    padding: 25px;
+    cursor: pointer;
+    transition: all 0.3s;
+    text-align: center;
+    min-height: 200px;
+}
+
+.mail-type-icon {
+    font-size: 42px;
+    margin-bottom: 16px;
+    display: block;
+}
+
+.wizard-mail-type-card h3 {
+    margin: 0 0 10px 0;
+    color: #2c3e50;
+    font-size: 18px;
+    font-weight: 600;
+}
+
+.wizard-template-library {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 25px;
+    margin-top: 20px;
+}
+
+.wizard-template-card {
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: all 0.3s;
+    min-height: 180px;
+}
+
+.wizard-template-preview {
+    height: 100px;
+    background: #f8f9fa;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 38px;
+    color: #667eea;
+    border-bottom: 1px solid #e9ecef;
+}
+
+.wizard-recipient-list {
+    max-height: 500px;
+    overflow-y: auto;
+    border: 1px solid #e9ecef;
+    border-radius: 10px;
+    padding: 20px;
+    background: white;
+}
+
+.wizard-summary {
+    background: #f8f9fa;
+    border-radius: 12px;
+    padding: 25px;
+    margin-bottom: 30px;
+    border: 1px solid #e9ecef;
+}


### PR DESCRIPTION
## Summary
- allow wizard modal to use almost the entire viewport width
- enlarge editor layout, preview and controls
- improve spacing and typography of form elements
- extend other wizard steps for better large-screen usage

## Testing
- `npm install` *(ran earlier)*
- `PORT=8080 node index.js &`
- `node test-auth.js`


------
https://chatgpt.com/codex/tasks/task_e_685fdc2cf8d083239fa397c1c7d4a23c