### PR TITLE
Implement missing email HTML helper

### DIFF
--- a/js/mail-wizard.js
+++ b/js/mail-wizard.js
@@ -2375,6 +2375,28 @@ function generateWizardButtons() {
         }
     }
 
+    /**
+     * Generiert vollständiges E-Mail-HTML
+     */
+    function generateCompleteEmailHTML(content, subject = '') {
+        return `<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>${subject || 'E-Mail'}</title>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; margin: 0; padding: 20px; background-color: #f4f4f4; }
+        .email-container { max-width: 600px; margin: 0 auto; background: white; padding: 30px; border-radius: 10px; }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        ${content}
+    </div>
+</body>
+</html>`;
+    }
+
     // ===== PUBLIC API =====
     return {
         // Core functions


### PR DESCRIPTION
## Summary
- add `generateCompleteEmailHTML` before the public API section in `js/mail-wizard.js`

## Testing
- `node backend/test-auth.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6860029ff2b883238063efa1dd4dfd0e