### PR TITLE
Fix missing generateFullHTML utility

### DIFF
--- a/js/mail-wizard.js
+++ b/js/mail-wizard.js
@@ -2397,6 +2397,10 @@ function generateWizardButtons() {
 </html>`;
     }
 
+    function generateFullHTML(content) {
+        return `<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body>${content}</body></html>`;
+    }
+
     // ===== PUBLIC API =====
     return {
         // Core functions


### PR DESCRIPTION
## Summary
- add `generateFullHTML` helper in the mail wizard

## Testing
- `npm install` in backend
- `PORT=8080 node index.js &`
- `node test-auth.js`


------
https://chatgpt.com/codex/tasks/task_e_686003964ed083239e1a72f9f4f344fe