### PR TITLE
Remove obsolete dashboard stats section

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,21 +87,6 @@
                     </button>
                 </div>
 
-                <!-- Dashboard Stats -->
-                <div class="wizard-recipient-stats">
-                    <div class="recipient-stat-card">
-                        <div class="stat-number" id="recipientCount">0</div>
-                        <div class="stat-label">Empfänger</div>
-                    </div>
-                    <div class="recipient-stat-card">
-                        <div class="stat-number" id="templateCount">0</div>
-                        <div class="stat-label">Templates</div>
-                    </div>
-                    <div class="recipient-stat-card">
-                        <div class="stat-number" id="lastCampaign">-</div>
-                        <div class="stat-label">Letzte Kampagne</div>
-                    </div>
-                </div>
 
                 <!-- Quick Actions -->
                 <div class="action-grid">


### PR DESCRIPTION
## Summary
- prune dashboard stats from index page

## Testing
- `npm install` in backend
- `PORT=8080 node index.js &`
- `node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_686007cbe8208323b5ca4ac2d00836c9