### PR TITLE
Improve preview system and add external CSS

### DIFF
--- a/css/email-preview.css
+++ b/css/email-preview.css
@@ -1,0 +1,34 @@
+/* E-Mail Preview Styles */
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+    line-height: 1.6;
+    color: #333;
+    background: #f4f4f4;
+    margin: 0;
+    padding: 20px;
+    font-size: 16px;
+}
+
+.email-container {
+    max-width: 600px;
+    margin: 0 auto;
+    background: white;
+    padding: 30px;
+    border-radius: 10px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+    border: 1px solid #e9ecef;
+}
+
+h1, h2, h3 { color: #2c3e50; margin: 0 0 16px 0; font-weight: 600; }
+h1 { font-size: 28px; }
+h2 { font-size: 24px; }
+h3 { font-size: 20px; }
+
+p { margin: 0 0 16px 0; line-height: 1.6; }
+a { color: #4a90e2; text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+ul, ol { margin: 0 0 16px 0; padding-left: 24px; }
+li { margin-bottom: 8px; }


### PR DESCRIPTION
## Summary
- optimize wizard preview generation and use external CSS
- add `email-preview.css` for preview iframe styling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68600d9ba3b083239ba1613aab51d64c