### PR TITLE
Fix missing stylesheet on landing page

### DIFF
--- a/generate-version.js
+++ b/generate-version.js
@@ -38,7 +38,7 @@ function displayVersion() {
 }
 
 function insertVersionedCSS() {
-    const href = 'styles.css?v=' + window.APP_VERSION.buildNumber;
+    const href = 'css/index.css?v=' + window.APP_VERSION.buildNumber;
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.href = href;
@@ -46,7 +46,7 @@ function insertVersionedCSS() {
     link.onerror = () => {
         const fallback = document.createElement('link');
         fallback.rel = 'stylesheet';
-        fallback.href = 'styles.css';
+        fallback.href = 'css/index.css';
         fallback.onload = () => document.body.classList.add('css-loaded');
         document.head.appendChild(fallback);
     };

--- a/js/version.js
+++ b/js/version.js
@@ -1,5 +1,5 @@
 // Auto-generated version file
-window.APP_VERSION = {"version":"2.0.125012","fullVersion":"2.0.125012 (2025-06-28 15:36:52)","buildDate":"2025-06-28 15:36:52","buildNumber":"125012","timestamp":1751125012};
+window.APP_VERSION = {"version":"2.0.128279","fullVersion":"2.0.128279 (2025-06-28 16:31:19)","buildDate":"2025-06-28 16:31:19","buildNumber":"128279","timestamp":1751128279};
 
 function displayVersion() {
     const versionElements = document.querySelectorAll('.app-version');
@@ -16,7 +16,7 @@ function displayVersion() {
 }
 
 function insertVersionedCSS() {
-    const href = 'styles.css?v=' + window.APP_VERSION.buildNumber;
+    const href = 'css/index.css?v=' + window.APP_VERSION.buildNumber;
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.href = href;
@@ -24,7 +24,7 @@ function insertVersionedCSS() {
     link.onerror = () => {
         const fallback = document.createElement('link');
         fallback.rel = 'stylesheet';
-        fallback.href = 'styles.css';
+        fallback.href = 'css/index.css';
         fallback.onload = () => document.body.classList.add('css-loaded');
         document.head.appendChild(fallback);
     };


### PR DESCRIPTION
## Summary
- load `css/index.css` instead of removed `styles.css`
- regenerate version file after updating path

## Testing
- `npm install`
- `PORT=8080 node index.js &` then `node test-auth.js`

------
https://chatgpt.com/codex/tasks/task_e_686018695c748323a7a0e1f1b48ba308